### PR TITLE
fix(conditionals): Ensure proper indentation

### DIFF
--- a/bake/core/rules/conditionals.py
+++ b/bake/core/rules/conditionals.py
@@ -41,21 +41,23 @@ class ConditionalRule(FormatterPlugin):
             # Handle conditional keywords
             if self._is_conditional_start(stripped):
                 # Conditional start: ifeq, ifneq, ifdef, ifndef
-                formatted_line = stripped
+                formatted_line = base_indent * indent_level + stripped
                 formatted_lines.append(formatted_line)
                 indent_level += 1
                 if formatted_line != original_line.rstrip():
                     changed = True
             elif self._is_conditional_middle(stripped):
                 # Middle: else, else if
-                formatted_line = stripped if indent_level > 0 else stripped
+                # Remove indent before rendering 'else' to match the matching 'if'
+                indent_for_else = max(indent_level - 1, 0)
+                formatted_line = base_indent * indent_for_else + stripped
                 formatted_lines.append(formatted_line)
                 if formatted_line != original_line.rstrip():
                     changed = True
             elif self._is_conditional_end(stripped):
                 # Conditional end: endif
                 indent_level = max(0, indent_level - 1)
-                formatted_line = stripped
+                formatted_line = base_indent * indent_level + stripped
                 formatted_lines.append(formatted_line)
                 if formatted_line != original_line.rstrip():
                     changed = True

--- a/tests/fixtures/nested_conditional_indentation/expected.mk
+++ b/tests/fixtures/nested_conditional_indentation/expected.mk
@@ -1,0 +1,30 @@
+ifeq ($(CFG_WITH_LONGTESTS),yes)
+    ifeq ($(DRIVER_STD),newest)
+        CPPFLAGS += $(CFG_CXXFLAGS_STD)
+    else
+        CPPFLAGS += else_term
+    endif
+    ifneq ($(DRIVER_STD),newest)
+        ifneq ($(DRIVER_STD),newest)
+            CPPFLAGS += ifneq_term
+        endif
+    endif
+endif
+
+define TEST_SNAP_template
+mkdir -p $(TEST_SNAP_DIR)
+rm -rf $(TEST_SNAP_DIR)/obj_$(1)
+cp -r obj_$(1) $(TEST_SNAP_DIR)/
+find $(TEST_SNAP_DIR)/obj_$(1) \( $(TEST_SNAP_IGNORE:%=-name "%" -o) \
+  -type f -executable \) -prune | xargs rm -r
+endef
+
+ifeq ($(FOO),yes)
+define FOO_template
+something
+endef
+else
+define FOO_template
+something_else
+endef
+endif

--- a/tests/fixtures/nested_conditional_indentation/input.mk
+++ b/tests/fixtures/nested_conditional_indentation/input.mk
@@ -1,0 +1,30 @@
+ifeq ($(CFG_WITH_LONGTESTS),yes)
+ifeq ($(DRIVER_STD),newest)
+CPPFLAGS += $(CFG_CXXFLAGS_STD)
+else
+CPPFLAGS += else_term
+endif
+ifneq ($(DRIVER_STD),newest)
+ifneq ($(DRIVER_STD),newest)
+CPPFLAGS += ifneq_term
+endif
+endif
+endif
+
+define TEST_SNAP_template
+mkdir -p $(TEST_SNAP_DIR)
+rm -rf $(TEST_SNAP_DIR)/obj_$(1)
+cp -r obj_$(1) $(TEST_SNAP_DIR)/
+find $(TEST_SNAP_DIR)/obj_$(1) \( $(TEST_SNAP_IGNORE:%=-name "%" -o) \
+  -type f -executable \) -prune | xargs rm -r
+endef
+
+ifeq ($(FOO),yes)
+define FOO_template
+something
+endef
+else
+define FOO_template
+something_else
+endef
+endif

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -173,6 +173,24 @@ class TestConditionalBlocks:
         assert result.changed
         # Basic test for conditional handling
 
+    def test_nested_conditional_indentation(self):
+        """Test nested conditional indentation fixture."""
+        config = Config(formatter=FormatterConfig())
+        formatter = MakefileFormatter(config)
+
+        input_file = Path("tests/fixtures/nested_conditional_indentation/input.mk")
+        expected_file = Path(
+            "tests/fixtures/nested_conditional_indentation/expected.mk"
+        )
+
+        input_lines = input_file.read_text(encoding="utf-8").splitlines()
+        expected_lines = expected_file.read_text(encoding="utf-8").splitlines()
+
+        formatted_lines, errors = formatter.format_lines(input_lines)
+
+        assert not errors
+        assert formatted_lines == expected_lines
+
 
 class TestLineContinuations:
     """Test line continuation formatting."""


### PR DESCRIPTION
Fixes indentation logic for conditional blocks. (#17)

- Conditional start lines (e.g. `ifeq`) are indented based on the current `indent_level`.

- Conditional middle lines (e.g. `else`) are indented one level less than the current `indent_level` to match the corresponding `if`.

- Conditional end lines (e.g. `endif`) are indented at the same level as the corresponding `if`.