### PR TITLE
fix(install): WARNING: typer 0.12.5 does not provide the extra 'all' (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Disabling formatting on a piece of code to turn off formatting within a region. This should suppress all changes (See [#26](https://github.com/EbodShojaei/bake/issues/26). Thanks @wsnyder!)
+- Resolve `typer` install error (reproduced on version `0.16.0`) (See [#25](https://github.com/EbodShojaei/bake/issues/25). Thanks @Dobatymo!)
 
 ## [1.2.3]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 dependencies = [
-    "typer[all] >= 0.9.0",
+    "typer >= 0.9.0",
     "rich >= 13.0.0",
     "tomli >= 1.2.1; python_version < '3.11'",
 ]


### PR DESCRIPTION
Resolves https://github.com/EbodShojaei/bake/issues/25