### PR TITLE
fix(recipe_validation): treat -include as directive, not recipe

### DIFF
--- a/mbake/core/rules/recipe_validation.py
+++ b/mbake/core/rules/recipe_validation.py
@@ -104,6 +104,7 @@ class RecipeValidationRule(FormatterPlugin):
             or stripped.startswith(
                 (
                     "include",
+                    "-include",
                     "export",
                     "unexport",
                     "define",

--- a/tests/fixtures/includes_and_exports/expected.mk
+++ b/tests/fixtures/includes_and_exports/expected.mk
@@ -51,3 +51,5 @@ include   $(wildcard $(INCLUDE_DIR)/*.mk)
 .PHONY: all
 all:
 	@echo "Makefile processed successfully."
+# -include after target should not be treated as part of recipe
+-include $(INCLUDE_DIR)

--- a/tests/fixtures/includes_and_exports/input.mk
+++ b/tests/fixtures/includes_and_exports/input.mk
@@ -51,3 +51,5 @@ include   $(wildcard $(INCLUDE_DIR)/*.mk)
 .PHONY: all
 all:
 	@echo "Makefile processed successfully." 
+# -include after target should not be treated as part of recipe
+-include $(INCLUDE_DIR)


### PR DESCRIPTION
Lines starting with '-include' after a target were treated as recipe lines and indented with tabs.

See #73

According to [https://www.gnu.org/software/make/manual/html_node/Include.html]()
> Extra spaces are allowed and ignored at the beginning of the line, but the first character must not be a tab (or the value of .RECIPEPREFIX)—if the line begins with a tab, it will be considered a recipe line.

I am not sure if it is also of interest for formatter to treat -include as recipe if it is followed by tab or value of .RECIPEPREFIX.

