### PR TITLE
(add) new `--quiet` and `--silent` flags

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -411,7 +411,10 @@ def format(
     ),
     debug: bool = typer.Option(False, "--debug", help="Enable debug output."),
     quiet: bool = typer.Option(
-        False, "--quiet", "-q", help="Print diagnostics, but nothing else."
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress all output. With --check, print diagnostics but nothing else.",
     ),
     silent: bool = typer.Option(
         False,
@@ -580,8 +583,8 @@ def format(
                                     f"[red]Error:[/red] {escape(error)}"
                                 )
 
-                # Only show warnings in check mode, verbose mode, or quiet mode
-                if warnings and not silent and (check or verbose or quiet):
+                # Only show warnings in check mode or verbose mode
+                if warnings and not silent and (check or verbose):
                     for warning in warnings:
                         if config.gnu_error_format:
                             # GNU standard format: filename:line: Warning: message
@@ -625,9 +628,10 @@ def format(
                                 f"[yellow]Would reformat:[/yellow] {file_path}"
                             )
                         else:
-                            output_console.print(
-                                f"[green]Formatted:[/green] {file_path}"
-                            )
+                            if not quiet:
+                                output_console.print(
+                                    f"[green]Formatted:[/green] {file_path}"
+                                )
 
                             # Validate syntax if requested
                             if validate_syntax:

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -141,9 +141,19 @@ align_across_comments = false
 """
 
 
-def setup_logging(verbose: bool = False, debug: bool = False) -> None:
+def setup_logging(
+    verbose: bool = False,
+    debug: bool = False,
+    quiet: bool = False,
+    silent: bool = False,
+) -> None:
     """Set up logging configuration."""
-    level = logging.DEBUG if debug else (logging.INFO if verbose else logging.WARNING)
+    if silent:
+        level = logging.CRITICAL
+    elif quiet:
+        level = logging.WARNING
+    else:
+        level = logging.DEBUG if debug else (logging.INFO if verbose else logging.WARNING)
 
     logging.basicConfig(
         level=level,
@@ -400,6 +410,15 @@ def format(
         False, "--verbose", "-v", help="Enable verbose output."
     ),
     debug: bool = typer.Option(False, "--debug", help="Enable debug output."),
+    quiet: bool = typer.Option(
+        False, "--quiet", "-q", help="Print diagnostics, but nothing else."
+    ),
+    silent: bool = typer.Option(
+        False,
+        "--silent",
+        "-s",
+        help="Disable all logging (but still exit with status code '1' upon detecting diagnostics).",
+    ),
     config_file: Optional[Path] = typer.Option(
         None, "--config", help="Path to configuration file (default: ~/.bake.toml)."
     ),
@@ -414,7 +433,7 @@ def format(
     ),
 ) -> None:
     """Format Makefiles according to style rules (use 'validate' command for syntax checking)."""
-    setup_logging(verbose, debug)
+    setup_logging(verbose, debug, quiet, silent)
 
     try:
         # Load configuration with fallback to defaults
@@ -442,12 +461,14 @@ def format(
             result = formatter.format(content)
 
             if result.errors:
-                for error in result.errors:
-                    print(f"Error: {error}", file=sys.stderr)
+                if not silent:
+                    for error in result.errors:
+                        print(f"Error: {error}", file=sys.stderr)
                 raise typer.Exit(2)
 
             if check and content != result.content:
-                output_console.print("[yellow]Would reformat stdin[/yellow]")
+                if not silent:
+                    output_console.print("[yellow]Would reformat stdin[/yellow]")
                 raise typer.Exit(1)
 
             # Write formatted content to stdout
@@ -523,41 +544,44 @@ def format(
 
                 if errors:
                     any_errors = True
-                    for error in errors:
-                        if config.gnu_error_format:
-                            # GNU standard format: filename:line: Error: message
-                            # Check if error already has line number in format:
-                            # - "10: Error:" or "10: Warning:"
-                            # - "Makefile:10: Error:" or "Makefile:10: Warning:"
-                            has_line_number = re.match(
-                                r"^(\d+|Makefile:\d+):\s*(Warning|Error):", error
-                            )
-                            if has_line_number:
-                                # Error already has line number, prepend filename if not already present
-                                if error.startswith("Makefile:"):
-                                    # Replace "Makefile:" with actual filename
-                                    error_with_file = error.replace(
-                                        "Makefile:", f"{file_path}:", 1
-                                    )
-                                    output_console.print(
-                                        f"[red]{escape(error_with_file)}[/red]"
-                                    )
+                    if not silent:
+                        for error in errors:
+                            if config.gnu_error_format:
+                                # GNU standard format: filename:line: Error: message
+                                # Check if error already has line number in format:
+                                # - "10: Error:" or "10: Warning:"
+                                # - "Makefile:10: Error:" or "Makefile:10: Warning:"
+                                has_line_number = re.match(
+                                    r"^(\d+|Makefile:\d+):\s*(Warning|Error):", error
+                                )
+                                if has_line_number:
+                                    # Error already has line number, prepend filename if not already present
+                                    if error.startswith("Makefile:"):
+                                        # Replace "Makefile:" with actual filename
+                                        error_with_file = error.replace(
+                                            "Makefile:", f"{file_path}:", 1
+                                        )
+                                        output_console.print(
+                                            f"[red]{escape(error_with_file)}[/red]"
+                                        )
+                                    else:
+                                        # Just prepend filename
+                                        output_console.print(
+                                            f"[red]{file_path}:{escape(error)}[/red]"
+                                        )
                                 else:
-                                    # Just prepend filename
+                                    # Error doesn't have line number, add generic format
                                     output_console.print(
-                                        f"[red]{file_path}:{escape(error)}[/red]"
+                                        f"[red]{file_path}: Error: {escape(error)}[/red]"
                                     )
                             else:
-                                # Error doesn't have line number, add generic format
+                                # Traditional format
                                 output_console.print(
-                                    f"[red]{file_path}: Error: {escape(error)}[/red]"
+                                    f"[red]Error:[/red] {escape(error)}"
                                 )
-                        else:
-                            # Traditional format
-                            output_console.print(f"[red]Error:[/red] {escape(error)}")
 
-                # Only show warnings in check mode or verbose mode
-                if warnings and (check or verbose):
+                # Only show warnings in check mode, verbose mode, or quiet mode
+                if warnings and not silent and (check or verbose or quiet):
                     for warning in warnings:
                         if config.gnu_error_format:
                             # GNU standard format: filename:line: Warning: message
@@ -595,35 +619,38 @@ def format(
 
                 if changed:
                     any_changed = True
-                    if check:
-                        output_console.print(
-                            f"[yellow]Would reformat:[/yellow] {file_path}"
-                        )
-                    else:
-                        output_console.print(f"[green]Formatted:[/green] {file_path}")
+                    if not silent:
+                        if check:
+                            output_console.print(
+                                f"[yellow]Would reformat:[/yellow] {file_path}"
+                            )
+                        else:
+                            output_console.print(
+                                f"[green]Formatted:[/green] {file_path}"
+                            )
 
-                        # Validate syntax if requested
-                        if validate_syntax:
-                            try:
-                                proc = subprocess.run(
-                                    ["make", "-f", str(file_path), "--dry-run"],
-                                    capture_output=True,
-                                    text=True,
-                                    timeout=5,
-                                )
-                                if proc.returncode != 0:
-                                    output_console.print(
-                                        "[red]Warning:[/red] Formatted file has syntax errors"
+                            # Validate syntax if requested
+                            if validate_syntax:
+                                try:
+                                    proc = subprocess.run(
+                                        ["make", "-f", str(file_path), "--dry-run"],
+                                        capture_output=True,
+                                        text=True,
+                                        timeout=5,
                                     )
-                                    any_errors = True
-                            except (subprocess.TimeoutExpired, FileNotFoundError):
-                                pass  # Skip validation if make not available
+                                    if proc.returncode != 0:
+                                        output_console.print(
+                                            "[red]Warning:[/red] Formatted file has syntax errors"
+                                        )
+                                        any_errors = True
+                                except (subprocess.TimeoutExpired, FileNotFoundError):
+                                    pass  # Skip validation if make not available
 
-                elif verbose:
+                elif verbose and not silent:
                     output_console.print(f"[dim]Already formatted:[/dim] {file_path}")
 
         # Show summary
-        if len(files) > 1:
+        if len(files) > 1 and not silent and not quiet:
             output_console.print(
                 f"\n[bold]Summary:[/bold] Processed {len(files)} files"
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,7 +232,7 @@ class TestCLIQuietSilentFlags:
         )
 
     def test_quiet_flag_suppresses_non_diagnostics(self, runner, test_config):
-        """Test that --quiet suppresses non-diagnostic output like summary."""
+        """Test that --quiet suppresses all output during normal formatting."""
         input_content = "target:\n\techo hello"
 
         with patch("mbake.cli.Config.load_or_default", return_value=test_config):
@@ -254,6 +254,36 @@ class TestCLIQuietSilentFlags:
 
         assert result.exit_code == 0
         assert result.stdout == input_content
+
+    def test_quiet_check_shows_would_reformat(self, runner, test_config):
+        """Test that --quiet --check shows 'Would reformat' diagnostic."""
+        # Input that needs formatting (unspaced assignment)
+        input_content = "VAR=value\ntarget:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app,
+                ["format", "--stdin", "--check", "--quiet"],
+                input=input_content,
+            )
+
+        assert result.exit_code == 1
+        assert "Would reformat" in result.stdout
+
+    def test_quiet_check_no_reformat_needed_no_output(self, runner, test_config):
+        """Test that --quiet --check exits 0 when already formatted."""
+        # Input that is already well-formatted (no changes needed)
+        input_content = "target:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app,
+                ["format", "--stdin", "--check", "--quiet"],
+                input=input_content,
+            )
+
+        assert result.exit_code == 0
+        assert "Would reformat" not in result.stdout
 
     def test_silent_flag_suppresses_all_output(self, runner, test_config):
         """Test that --silent suppresses all output."""
@@ -313,3 +343,4 @@ class TestCLIQuietSilentFlags:
 
         # Should exit 1 (would reformat) and print the diagnostic
         assert result.exit_code == 1
+        assert "Would reformat" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,3 +208,108 @@ main.o: main.c
 
 # Note: Help text tests removed due to ANSI color code issues in CI
 # The core --stdin functionality is tested in TestCLIFormat class
+
+
+class TestCLIQuietSilentFlags:
+    """Test --quiet and --silent flag functionality."""
+
+    @pytest.fixture
+    def runner(self):
+        """Create a CLI runner for testing."""
+        return CliRunner()
+
+    @pytest.fixture
+    def test_config(self):
+        """Create a test configuration with consistent settings."""
+        return Config(
+            formatter=FormatterConfig(
+                space_around_assignment=True,
+                group_phony_declarations=False,
+                phony_at_top=False,
+                auto_insert_phony_declarations=False,
+                ensure_final_newline=False,
+            )
+        )
+
+    def test_quiet_flag_suppresses_non_diagnostics(self, runner, test_config):
+        """Test that --quiet suppresses non-diagnostic output like summary."""
+        input_content = "target:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app, ["format", "--stdin", "--quiet"], input=input_content
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout == input_content
+
+    def test_quiet_flag_short_form(self, runner, test_config):
+        """Test that -q short form works the same as --quiet."""
+        input_content = "target:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app, ["format", "--stdin", "-q"], input=input_content
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout == input_content
+
+    def test_silent_flag_suppresses_all_output(self, runner, test_config):
+        """Test that --silent suppresses all output."""
+        input_content = "target:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app, ["format", "--stdin", "--silent"], input=input_content
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout == input_content
+
+    def test_silent_flag_short_form(self, runner, test_config):
+        """Test that -s short form works the same as --silent."""
+        input_content = "target:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app, ["format", "--stdin", "-s"], input=input_content
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout == input_content
+
+    def test_silent_still_exits_with_error_on_check_failure(
+        self, runner, test_config
+    ):
+        """Test that --silent still exits with code 1 when check finds reformattable files."""
+        # Input that needs formatting (unspaced assignment)
+        input_content = "VAR=value\ntarget:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app,
+                ["format", "--stdin", "--check", "--silent"],
+                input=input_content,
+            )
+
+        # Should exit 1 (would reformat) but with no output
+        assert result.exit_code == 1
+        assert result.stdout == ""
+
+    def test_quiet_still_exits_with_error_on_check_failure(
+        self, runner, test_config
+    ):
+        """Test that --quiet still exits with code 1 when check finds reformattable files."""
+        # Input that needs formatting (unspaced assignment)
+        input_content = "VAR=value\ntarget:\n\techo hello"
+
+        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+            result = runner.invoke(
+                app,
+                ["format", "--stdin", "--check", "--quiet"],
+                input=input_content,
+            )
+
+        # Should exit 1 (would reformat) and print the diagnostic
+        assert result.exit_code == 1


### PR DESCRIPTION
This PR adds `--quiet`/`-q` and `--silent`/`-s` flags to the `format` command, following the ruff convention.
```
 --quiet     -q            Suppress all output. With --check, print diagnostics but nothing else.                                                                             
 --silent    -s            Disable all logging (but still exit with status code '1' upon detecting diagnostics). 
```