### PR TITLE
Feat(Config): Add support for XDG_CONFIG_HOME.

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -157,7 +157,9 @@ def setup_logging(verbose: bool = False, debug: bool = False) -> None:
 def init(
     force: bool = typer.Option(False, "--force", help="Overwrite existing config."),
     config_file: Optional[Path] = typer.Option(
-        None, "--config", help="Path to configuration file (default: ~/.bake.toml)."
+        None,
+        "--config",
+        help="Path to configuration file (default: {XDG_CONFIG_HOME}/bake.toml).",
     ),
 ) -> None:
     """Initialize configuration file with defaults."""
@@ -199,7 +201,7 @@ def config(
     ),
 ) -> None:
     """Show current configuration."""
-    config_path = config_file or Path.home() / ".bake.toml"
+    config_path = config_file or Config.determine_config_path()
 
     if show_path:
         console.print(str(config_path))

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -75,7 +75,7 @@ class Config:
     )
 
     @staticmethod
-    def _xdg_config_path() -> Path:
+    def determine_config_path() -> Path:
         """Return the XDG config path for mbake.
 
         Order of options:
@@ -99,7 +99,7 @@ class Config:
         ( Checks if home config exists, else checks if XDG_CONFIG_HOME exists,
          else falls back to ~/.config/bake.toml)"""
         if config_path is None:
-            config_path = cls._xdg_config_path()
+            config_path = cls.determine_config_path()
 
         if not config_path.exists():
             raise FileNotFoundError(
@@ -177,7 +177,7 @@ class Config:
         # directory
 
         current_dir_config = Path.cwd() / ".bake.toml"
-        xdg_home_config = cls._xdg_config_path()
+        xdg_home_config = cls.determine_config_path()
 
         if current_dir_config.exists():
             try:

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -1,5 +1,6 @@
 """Configuration loading for mbake."""
 
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -73,16 +74,37 @@ class Config:
         False  # Wrap long error messages (can interfere with IDE parsing)
     )
 
+    @staticmethod
+    def _xdg_config_path() -> Path:
+        """Return the XDG config path for mbake.
+
+        Order of options:
+          1. `~/.bake.toml — if the file exists
+          2. `$XDG_CONFIG_HOME/bake.toml' — if `$XDG_CONFIG_HOME' is set.
+          3. `~/.config/bake.toml — XDG default.
+        """
+        home_path = Path.home() / ".bake.toml"
+        if home_path.exists():
+            return home_path
+
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        if xdg_config_home:
+            return Path(xdg_config_home) / "bake.toml"
+
+        return Path.home() / ".config" / "bake.toml"
+
     @classmethod
     def load(cls, config_path: Optional[Path] = None) -> "Config":
-        """Load configuration from ~/.bake.toml."""
+        """Load configuration from XDG config path
+        ( Checks if home config exists, else checks if XDG_CONFIG_HOME exists,
+         else falls back to ~/.config/bake.toml)"""
         if config_path is None:
-            config_path = Path.home() / ".bake.toml"
+            config_path = cls._xdg_config_path()
 
         if not config_path.exists():
             raise FileNotFoundError(
                 f"Configuration file not found at {config_path}. "
-                "Please create ~/.bake.toml with your formatting preferences."
+                "Please create ~/.config/bake.toml with your formatting preferences."
             )
 
         try:
@@ -151,10 +173,11 @@ class Config:
                     raise
                 return cls(formatter=FormatterConfig())
 
-        # Try to find config file in current directory first, then home directory
+        # Try to find config file in current directory first, then xdg_config
+        # directory
 
         current_dir_config = Path.cwd() / ".bake.toml"
-        home_config = Path.home() / ".bake.toml"
+        xdg_home_config = cls._xdg_config_path()
 
         if current_dir_config.exists():
             try:
@@ -163,9 +186,9 @@ class Config:
                 # If current directory config is invalid, fall back to home directory
                 pass
 
-        if home_config.exists():
+        if xdg_home_config.exists():
             try:
-                return cls.load(home_config)
+                return cls.load(xdg_home_config)
             except Exception:
                 # If home directory config is invalid, fall back to defaults
                 pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,10 +14,10 @@ import pytest
 
 from mbake.config import Config, FormatterConfig
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _write_toml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -35,11 +35,12 @@ def _fake_cwd(tmp: str):
 
 
 # ---------------------------------------------------------------------------
-# _xdg_config_path resolution
+# determine_config_path resolution
 # ---------------------------------------------------------------------------
 
+
 class TestXdgConfigPath:
-    """Tests for Config._xdg_config_path() resolution order."""
+    """Tests for Config.determine_config_path() resolution order."""
 
     def setup_method(self):
         os.environ.pop("XDG_CONFIG_HOME", None)
@@ -49,12 +50,14 @@ class TestXdgConfigPath:
 
     def test_home_bake_toml_wins_over_xdg(self):
         """~/.bake.toml existing takes priority even when XDG_CONFIG_HOME is set."""
-        with tempfile.TemporaryDirectory() as fake_home, \
-             tempfile.TemporaryDirectory() as xdg:
+        with (
+            tempfile.TemporaryDirectory() as fake_home,
+            tempfile.TemporaryDirectory() as xdg,
+        ):
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\n")
             os.environ["XDG_CONFIG_HOME"] = xdg
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert result == Path(fake_home) / ".bake.toml"
 
     def test_home_bake_toml_wins_without_xdg(self):
@@ -62,23 +65,25 @@ class TestXdgConfigPath:
         with tempfile.TemporaryDirectory() as fake_home:
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\n")
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert result == Path(fake_home) / ".bake.toml"
 
     def test_xdg_env_used_when_home_file_absent(self):
         """$XDG_CONFIG_HOME/bake.toml is used when ~/.bake.toml does not exist."""
-        with tempfile.TemporaryDirectory() as fake_home, \
-             tempfile.TemporaryDirectory() as xdg:
+        with (
+            tempfile.TemporaryDirectory() as fake_home,
+            tempfile.TemporaryDirectory() as xdg,
+        ):
             os.environ["XDG_CONFIG_HOME"] = xdg
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert result == Path(xdg) / "bake.toml"
 
     def test_default_xdg_base_when_nothing_set(self):
         """Falls back to ~/.config/bake.toml when no XDG var and no ~/.bake.toml."""
         with tempfile.TemporaryDirectory() as fake_home:
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert result == Path(fake_home) / ".config" / "bake.toml"
 
     def test_empty_xdg_env_is_ignored(self):
@@ -86,14 +91,14 @@ class TestXdgConfigPath:
         with tempfile.TemporaryDirectory() as fake_home:
             os.environ["XDG_CONFIG_HOME"] = "   "
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert result == Path(fake_home) / ".config" / "bake.toml"
 
     def test_returned_path_may_not_exist(self):
         """_xdg_config_path does not require the file to exist."""
         with tempfile.TemporaryDirectory() as fake_home:
             with _fake_home(fake_home):
-                result = Config._xdg_config_path()
+                result = Config.determine_config_path()
             assert isinstance(result, Path)
             assert not result.exists()
 
@@ -101,6 +106,7 @@ class TestXdgConfigPath:
 # ---------------------------------------------------------------------------
 # Config.load()
 # ---------------------------------------------------------------------------
+
 
 class TestLoad:
     """Tests for Config.load()."""
@@ -153,7 +159,9 @@ class TestLoad:
     def test_loads_all_formatter_options(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "full.toml"
-            _write_toml(p, """\
+            _write_toml(
+                p,
+                """\
 [formatter]
 space_around_assignment = false
 space_before_colon = true
@@ -172,7 +180,8 @@ indent_nested_conditionals = true
 tab_width = 8
 align_variable_assignments = true
 align_across_comments = true
-""")
+""",
+            )
             f = Config.load(p).formatter
             assert f.space_around_assignment is False
             assert f.space_before_colon is True
@@ -197,6 +206,7 @@ align_across_comments = true
 # Config.load_or_default()
 # ---------------------------------------------------------------------------
 
+
 class TestLoadOrDefault:
     """Tests for Config.load_or_default() search-order cascade."""
 
@@ -207,8 +217,10 @@ class TestLoadOrDefault:
         os.environ.pop("XDG_CONFIG_HOME", None)
 
     def test_no_files_returns_defaults(self):
-        with tempfile.TemporaryDirectory() as fake_home, \
-             tempfile.TemporaryDirectory() as cwd:
+        with (
+            tempfile.TemporaryDirectory() as fake_home,
+            tempfile.TemporaryDirectory() as cwd,
+        ):
             with _fake_home(fake_home), _fake_cwd(cwd):
                 result = Config.load_or_default()
         assert isinstance(result, Config)
@@ -217,8 +229,10 @@ class TestLoadOrDefault:
 
     def test_cwd_config_beats_everything(self):
         """A .bake.toml in the current directory takes top priority."""
-        with tempfile.TemporaryDirectory() as cwd, \
-             tempfile.TemporaryDirectory() as fake_home:
+        with (
+            tempfile.TemporaryDirectory() as cwd,
+            tempfile.TemporaryDirectory() as fake_home,
+        ):
             _write_toml(Path(cwd) / ".bake.toml", "[formatter]\ntab_width = 7\n")
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 2\n")
             with _fake_home(fake_home), _fake_cwd(cwd):
@@ -227,8 +241,10 @@ class TestLoadOrDefault:
 
     def test_home_bake_toml_used_when_no_cwd_config(self):
         """~/.bake.toml is used when there is no cwd config."""
-        with tempfile.TemporaryDirectory() as cwd, \
-             tempfile.TemporaryDirectory() as fake_home:
+        with (
+            tempfile.TemporaryDirectory() as cwd,
+            tempfile.TemporaryDirectory() as fake_home,
+        ):
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 6\n")
             with _fake_home(fake_home), _fake_cwd(cwd):
                 result = Config.load_or_default()
@@ -236,9 +252,11 @@ class TestLoadOrDefault:
 
     def test_xdg_config_used_when_home_file_absent(self):
         """$XDG_CONFIG_HOME/bake.toml is used when ~/.bake.toml does not exist."""
-        with tempfile.TemporaryDirectory() as cwd, \
-             tempfile.TemporaryDirectory() as fake_home, \
-             tempfile.TemporaryDirectory() as xdg:
+        with (
+            tempfile.TemporaryDirectory() as cwd,
+            tempfile.TemporaryDirectory() as fake_home,
+            tempfile.TemporaryDirectory() as xdg,
+        ):
             _write_toml(Path(xdg) / "bake.toml", "[formatter]\ntab_width = 5\n")
             os.environ["XDG_CONFIG_HOME"] = xdg
             with _fake_home(fake_home), _fake_cwd(cwd):
@@ -268,8 +286,10 @@ class TestLoadOrDefault:
 
     def test_broken_cwd_config_falls_through_to_home(self):
         """Invalid cwd .bake.toml is skipped; home config is tried next."""
-        with tempfile.TemporaryDirectory() as cwd, \
-             tempfile.TemporaryDirectory() as fake_home:
+        with (
+            tempfile.TemporaryDirectory() as cwd,
+            tempfile.TemporaryDirectory() as fake_home,
+        ):
             (Path(cwd) / ".bake.toml").write_text("not valid toml !!!")
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 3\n")
             with _fake_home(fake_home), _fake_cwd(cwd):
@@ -278,8 +298,10 @@ class TestLoadOrDefault:
 
     def test_broken_home_config_falls_through_to_defaults(self):
         """Invalid home config returns defaults rather than raising."""
-        with tempfile.TemporaryDirectory() as cwd, \
-             tempfile.TemporaryDirectory() as fake_home:
+        with (
+            tempfile.TemporaryDirectory() as cwd,
+            tempfile.TemporaryDirectory() as fake_home,
+        ):
             (Path(fake_home) / ".bake.toml").write_text("not valid toml !!!")
             with _fake_home(fake_home), _fake_cwd(cwd):
                 result = Config.load_or_default()
@@ -289,6 +311,7 @@ class TestLoadOrDefault:
 # ---------------------------------------------------------------------------
 # Config.to_dict() round-trip
 # ---------------------------------------------------------------------------
+
 
 class TestToDict:
     """Tests for Config.to_dict()."""
@@ -306,13 +329,23 @@ class TestToDict:
         result = Config(formatter=FormatterConfig())
         keys = set(result.to_dict()["formatter"].keys())
         expected = {
-            "space_around_assignment", "space_before_colon", "space_after_colon",
-            "normalize_line_continuations", "max_line_length",
-            "auto_insert_phony_declarations", "group_phony_declarations", "phony_at_top",
-            "remove_trailing_whitespace", "ensure_final_newline",
-            "normalize_empty_lines", "max_consecutive_empty_lines",
-            "fix_missing_recipe_tabs", "indent_nested_conditionals", "tab_width",
-            "align_variable_assignments", "align_across_comments",
+            "space_around_assignment",
+            "space_before_colon",
+            "space_after_colon",
+            "normalize_line_continuations",
+            "max_line_length",
+            "auto_insert_phony_declarations",
+            "group_phony_declarations",
+            "phony_at_top",
+            "remove_trailing_whitespace",
+            "ensure_final_newline",
+            "normalize_empty_lines",
+            "max_consecutive_empty_lines",
+            "fix_missing_recipe_tabs",
+            "indent_nested_conditionals",
+            "tab_width",
+            "align_variable_assignments",
+            "align_across_comments",
         }
         assert keys == expected
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,325 @@
+"""Tests for configuration loading and XDG path resolution.
+
+Run from the project root:
+    pytest tests/test_config.py -v
+    pytest  # runs all tests including this file
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mbake.config import Config, FormatterConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_toml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _fake_home(tmp: str):
+    """Patch Path.home() to point at a temp directory."""
+    return patch("pathlib.Path.home", return_value=Path(tmp))
+
+
+def _fake_cwd(tmp: str):
+    """Patch Path.cwd() to point at a temp directory."""
+    return patch("pathlib.Path.cwd", return_value=Path(tmp))
+
+
+# ---------------------------------------------------------------------------
+# _xdg_config_path resolution
+# ---------------------------------------------------------------------------
+
+class TestXdgConfigPath:
+    """Tests for Config._xdg_config_path() resolution order."""
+
+    def setup_method(self):
+        os.environ.pop("XDG_CONFIG_HOME", None)
+
+    def teardown_method(self):
+        os.environ.pop("XDG_CONFIG_HOME", None)
+
+    def test_home_bake_toml_wins_over_xdg(self):
+        """~/.bake.toml existing takes priority even when XDG_CONFIG_HOME is set."""
+        with tempfile.TemporaryDirectory() as fake_home, \
+             tempfile.TemporaryDirectory() as xdg:
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\n")
+            os.environ["XDG_CONFIG_HOME"] = xdg
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert result == Path(fake_home) / ".bake.toml"
+
+    def test_home_bake_toml_wins_without_xdg(self):
+        """~/.bake.toml existing is returned when XDG_CONFIG_HOME is not set."""
+        with tempfile.TemporaryDirectory() as fake_home:
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\n")
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert result == Path(fake_home) / ".bake.toml"
+
+    def test_xdg_env_used_when_home_file_absent(self):
+        """$XDG_CONFIG_HOME/bake.toml is used when ~/.bake.toml does not exist."""
+        with tempfile.TemporaryDirectory() as fake_home, \
+             tempfile.TemporaryDirectory() as xdg:
+            os.environ["XDG_CONFIG_HOME"] = xdg
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert result == Path(xdg) / "bake.toml"
+
+    def test_default_xdg_base_when_nothing_set(self):
+        """Falls back to ~/.config/bake.toml when no XDG var and no ~/.bake.toml."""
+        with tempfile.TemporaryDirectory() as fake_home:
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert result == Path(fake_home) / ".config" / "bake.toml"
+
+    def test_empty_xdg_env_is_ignored(self):
+        """A blank/whitespace XDG_CONFIG_HOME is treated as unset."""
+        with tempfile.TemporaryDirectory() as fake_home:
+            os.environ["XDG_CONFIG_HOME"] = "   "
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert result == Path(fake_home) / ".config" / "bake.toml"
+
+    def test_returned_path_may_not_exist(self):
+        """_xdg_config_path does not require the file to exist."""
+        with tempfile.TemporaryDirectory() as fake_home:
+            with _fake_home(fake_home):
+                result = Config._xdg_config_path()
+            assert isinstance(result, Path)
+            assert not result.exists()
+
+
+# ---------------------------------------------------------------------------
+# Config.load()
+# ---------------------------------------------------------------------------
+
+class TestLoad:
+    """Tests for Config.load()."""
+
+    def test_loads_explicit_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "my.toml"
+            _write_toml(p, "[formatter]\ntab_width = 4\n")
+            result = Config.load(p)
+            assert result.formatter.tab_width == 4
+
+    def test_missing_explicit_path_raises_file_not_found(self):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            Config.load(Path("/nonexistent/path/config.toml"))
+        assert "bake.toml" in str(exc_info.value)
+
+    def test_invalid_toml_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "bad.toml"
+            p.write_text("this is not [ valid toml !!!")
+            with pytest.raises(ValueError):
+                Config.load(p)
+
+    def test_unknown_formatter_keys_are_ignored(self):
+        """Keys not in FormatterConfig are silently dropped."""
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "extra.toml"
+            _write_toml(p, "[formatter]\ntab_width = 3\nunknown_key = true\n")
+            result = Config.load(p)
+            assert result.formatter.tab_width == 3
+
+    def test_global_debug_and_verbose_flags(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "flags.toml"
+            _write_toml(p, "debug = true\nverbose = true\n")
+            result = Config.load(p)
+            assert result.debug is True
+            assert result.verbose is True
+
+    def test_empty_toml_returns_all_defaults(self):
+        """A TOML with no [formatter] section gives default FormatterConfig."""
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "empty.toml"
+            _write_toml(p, "# empty\n")
+            result = Config.load(p)
+            defaults = FormatterConfig()
+            assert result.formatter.tab_width == defaults.tab_width
+            assert result.formatter.max_line_length == defaults.max_line_length
+
+    def test_loads_all_formatter_options(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "full.toml"
+            _write_toml(p, """\
+[formatter]
+space_around_assignment = false
+space_before_colon = true
+space_after_colon = false
+normalize_line_continuations = false
+max_line_length = 80
+auto_insert_phony_declarations = true
+group_phony_declarations = true
+phony_at_top = true
+remove_trailing_whitespace = false
+ensure_final_newline = true
+normalize_empty_lines = false
+max_consecutive_empty_lines = 5
+fix_missing_recipe_tabs = false
+indent_nested_conditionals = true
+tab_width = 8
+align_variable_assignments = true
+align_across_comments = true
+""")
+            f = Config.load(p).formatter
+            assert f.space_around_assignment is False
+            assert f.space_before_colon is True
+            assert f.space_after_colon is False
+            assert f.normalize_line_continuations is False
+            assert f.max_line_length == 80
+            assert f.auto_insert_phony_declarations is True
+            assert f.group_phony_declarations is True
+            assert f.phony_at_top is True
+            assert f.remove_trailing_whitespace is False
+            assert f.ensure_final_newline is True
+            assert f.normalize_empty_lines is False
+            assert f.max_consecutive_empty_lines == 5
+            assert f.fix_missing_recipe_tabs is False
+            assert f.indent_nested_conditionals is True
+            assert f.tab_width == 8
+            assert f.align_variable_assignments is True
+            assert f.align_across_comments is True
+
+
+# ---------------------------------------------------------------------------
+# Config.load_or_default()
+# ---------------------------------------------------------------------------
+
+class TestLoadOrDefault:
+    """Tests for Config.load_or_default() search-order cascade."""
+
+    def setup_method(self):
+        os.environ.pop("XDG_CONFIG_HOME", None)
+
+    def teardown_method(self):
+        os.environ.pop("XDG_CONFIG_HOME", None)
+
+    def test_no_files_returns_defaults(self):
+        with tempfile.TemporaryDirectory() as fake_home, \
+             tempfile.TemporaryDirectory() as cwd:
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert isinstance(result, Config)
+        assert isinstance(result.formatter, FormatterConfig)
+        assert result.debug is False
+
+    def test_cwd_config_beats_everything(self):
+        """A .bake.toml in the current directory takes top priority."""
+        with tempfile.TemporaryDirectory() as cwd, \
+             tempfile.TemporaryDirectory() as fake_home:
+            _write_toml(Path(cwd) / ".bake.toml", "[formatter]\ntab_width = 7\n")
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 2\n")
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert result.formatter.tab_width == 7
+
+    def test_home_bake_toml_used_when_no_cwd_config(self):
+        """~/.bake.toml is used when there is no cwd config."""
+        with tempfile.TemporaryDirectory() as cwd, \
+             tempfile.TemporaryDirectory() as fake_home:
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 6\n")
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert result.formatter.tab_width == 6
+
+    def test_xdg_config_used_when_home_file_absent(self):
+        """$XDG_CONFIG_HOME/bake.toml is used when ~/.bake.toml does not exist."""
+        with tempfile.TemporaryDirectory() as cwd, \
+             tempfile.TemporaryDirectory() as fake_home, \
+             tempfile.TemporaryDirectory() as xdg:
+            _write_toml(Path(xdg) / "bake.toml", "[formatter]\ntab_width = 5\n")
+            os.environ["XDG_CONFIG_HOME"] = xdg
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert result.formatter.tab_width == 5
+
+    def test_explicit_path_used_directly(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "custom.toml"
+            _write_toml(p, "[formatter]\ntab_width = 9\n")
+            result = Config.load_or_default(config_path=p)
+        assert result.formatter.tab_width == 9
+
+    def test_explicit_missing_path_raises_when_explicit_true(self):
+        with pytest.raises(FileNotFoundError):
+            Config.load_or_default(
+                config_path=Path("/nonexistent/config.toml"),
+                explicit=True,
+            )
+
+    def test_explicit_missing_path_returns_defaults_when_explicit_false(self):
+        result = Config.load_or_default(
+            config_path=Path("/nonexistent/config.toml"),
+            explicit=False,
+        )
+        assert isinstance(result.formatter, FormatterConfig)
+
+    def test_broken_cwd_config_falls_through_to_home(self):
+        """Invalid cwd .bake.toml is skipped; home config is tried next."""
+        with tempfile.TemporaryDirectory() as cwd, \
+             tempfile.TemporaryDirectory() as fake_home:
+            (Path(cwd) / ".bake.toml").write_text("not valid toml !!!")
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 3\n")
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert result.formatter.tab_width == 3
+
+    def test_broken_home_config_falls_through_to_defaults(self):
+        """Invalid home config returns defaults rather than raising."""
+        with tempfile.TemporaryDirectory() as cwd, \
+             tempfile.TemporaryDirectory() as fake_home:
+            (Path(fake_home) / ".bake.toml").write_text("not valid toml !!!")
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()
+        assert isinstance(result.formatter, FormatterConfig)
+
+
+# ---------------------------------------------------------------------------
+# Config.to_dict() round-trip
+# ---------------------------------------------------------------------------
+
+class TestToDict:
+    """Tests for Config.to_dict()."""
+
+    def test_values_round_trip(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "rt.toml"
+            _write_toml(p, "[formatter]\ntab_width = 4\nmax_line_length = 100\n")
+            result = Config.load(p)
+        d = result.to_dict()
+        assert d["formatter"]["tab_width"] == 4
+        assert d["formatter"]["max_line_length"] == 100
+
+    def test_all_formatter_keys_present(self):
+        result = Config(formatter=FormatterConfig())
+        keys = set(result.to_dict()["formatter"].keys())
+        expected = {
+            "space_around_assignment", "space_before_colon", "space_after_colon",
+            "normalize_line_continuations", "max_line_length",
+            "auto_insert_phony_declarations", "group_phony_declarations", "phony_at_top",
+            "remove_trailing_whitespace", "ensure_final_newline",
+            "normalize_empty_lines", "max_consecutive_empty_lines",
+            "fix_missing_recipe_tabs", "indent_nested_conditionals", "tab_width",
+            "align_variable_assignments", "align_across_comments",
+        }
+        assert keys == expected
+
+    def test_global_keys_present(self):
+        result = Config(formatter=FormatterConfig())
+        d = result.to_dict()
+        assert "debug" in d
+        assert "verbose" in d
+        assert "gnu_error_format" in d
+        assert "wrap_error_messages" in d

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,9 +220,10 @@ class TestLoadOrDefault:
         with (
             tempfile.TemporaryDirectory() as fake_home,
             tempfile.TemporaryDirectory() as cwd,
+            _fake_home(fake_home),
+            _fake_cwd(cwd),
         ):
-            with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
+            result = Config.load_or_default()
         assert isinstance(result, Config)
         assert isinstance(result.formatter, FormatterConfig)
         assert result.debug is False


### PR DESCRIPTION
I added code that detects if the normal ```~/.bake.toml``` exists, if it does we use it (To not break previous config versions).

Else we check if ```XDG_CONFIG_HOME``` is set, if it does we use the config file ```XDG_CONFIG_HOME/bake.toml``` if this is not set; then theres a final fallback to ```~/.config/bake.toml``` for config file reading.

It still has a preference for .bake.toml in the current working directory above a global config.

Also added more tests for this new config finding feature, and all tests are passing.