### PR TITLE
(fix) explicitly tell pip to install pre-release versions

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -924,11 +924,15 @@ def update(
                 latest_prerelease if has_prerelease_update else latest_stable
             )
 
-        # Perform update
+        # Perform update (pip ignores pre-releases unless --pre is passed)
+        install_prerelease = bool(
+            latest_prerelease is not None and target_version == latest_prerelease
+        )
+
         console.print("📦 Updating mbake...", style="dim")
 
         with console.status("Installing update..."):
-            success = update_package("mbake")
+            success = update_package("mbake", prerelease=install_prerelease)
 
         if success:
             console.print(
@@ -941,6 +945,9 @@ def update(
             console.print("[red]❌ Update failed[/red]")
             console.print(
                 "Try updating manually with: [bold]pip install --upgrade mbake[/bold]"
+            )
+            console.print(
+                "For a pre-release: [bold]pip install --upgrade --pre mbake[/bold]"
             )
             raise typer.Exit(1)
 

--- a/mbake/utils/version_utils.py
+++ b/mbake/utils/version_utils.py
@@ -137,12 +137,19 @@ def check_for_updates(
         return False, latest_version, current_version
 
 
-def update_package(package_name: str = "mbake", use_pip: bool = True) -> bool:
+def update_package(
+    package_name: str = "mbake",
+    use_pip: bool = True,
+    *,
+    prerelease: bool = False,
+) -> bool:
     """Update the package using pip.
 
     Args:
         package_name: Name of the package to update
         use_pip: Whether to use pip for updating
+        prerelease: If True, pass ``--pre`` so pip can install pre-release versions
+            (a/b/rc, etc.). Required when upgrading to versions like ``1.4.6a1``.
 
     Returns:
         True if update was successful, False otherwise
@@ -151,8 +158,12 @@ def update_package(package_name: str = "mbake", use_pip: bool = True) -> bool:
         raise NotImplementedError("Only pip updates are currently supported")
 
     try:
-        # Use pip to update the package
-        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", package_name]
+        # Use pip to update the package (--pre is required for pre-releases; otherwise
+        # pip only considers stable releases and may leave the install unchanged.)
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade"]
+        if prerelease:
+            cmd.append("--pre")
+        cmd.append(package_name)
 
         result = subprocess.run(
             cmd,

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -10,6 +10,7 @@ from mbake.utils.version_utils import (
     get_pypi_version,
     is_development_install,
     parse_version,
+    update_package,
 )
 
 
@@ -200,6 +201,35 @@ class TestCheckForUpdates:
         assert update_available is False
         assert latest == "1.4.1"
         assert current == "1.4.1"
+
+
+class TestUpdatePackage:
+    """Tests for pip-based package updates."""
+
+    @patch("mbake.utils.version_utils.subprocess.run")
+    def test_stable_install_omits_pre_flag(self, mock_run):
+        """Stable upgrades must not pass --pre (pip would skip pre-releases anyway)."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert update_package("mbake", prerelease=False) is True
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "--pre" not in cmd
+        assert cmd[-1] == "mbake"
+
+    @patch("mbake.utils.version_utils.subprocess.run")
+    def test_prerelease_install_includes_pre_flag(self, mock_run):
+        """Pre-release upgrades must pass --pre so pip can install a/b/rc versions."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert update_package("mbake", prerelease=True) is True
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "--pre" in cmd
+        pre_idx = cmd.index("--pre")
+        assert cmd[pre_idx + 1] == "mbake"
 
 
 class TestIsDevelopmentInstall:


### PR DESCRIPTION
The updater called `pip install --upgrade` without `--pre`, so pip only installed stable releases. Upgrading to `v1.4.6a1` requires manually invoking `pip install --upgrade --pre mbake`; the next planned stable release `v1.4.6` will no longer require any manual invocations.