### PR TITLE
(add) support for automake conditional 'if' directive

### DIFF
--- a/mbake/core/rules/recipe_validation.py
+++ b/mbake/core/rules/recipe_validation.py
@@ -112,6 +112,7 @@ class RecipeValidationRule(FormatterPlugin):
                     "ifneq",
                     "ifdef",
                     "ifndef",
+                    "if ",
                     "else",
                     "endif",
                     "endef",

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1639,3 +1639,27 @@ class TestSpecialTargets:
 
         assert not errors
         assert formatted_lines == input_lines
+
+
+class TestAutomakeConditionals:
+    """Test automake-style conditional handling."""
+
+    def test_automake_if_not_converted_to_recipe(self):
+        """Test that automake 'if VARIABLE' is not treated as a recipe line."""
+        config = create_conservative_config()
+        formatter = MakefileFormatter(config)
+
+        input_lines = [
+            ".DELETE_ON_ERROR:",
+            "",
+            "if STRICT",
+            "  WERROR = -Werror",
+            "else",
+            "  WERROR =",
+            "endif",
+        ]
+
+        formatted_lines, errors, warnings = formatter.format_lines(input_lines)
+
+        assert "if STRICT" in formatted_lines
+        assert "\tif STRICT" not in formatted_lines


### PR DESCRIPTION
We use automake, that me we have `makefile.am`.  Automake support `if` in their `.am`:
```
https://www.gnu.org/software/automake/manual/html_node/Usage-of-Conditionals.html
```

 so I made a little change so that `if ` statement are not indented, so we can use `mbake` : ) And have a nice linted makefile! 
 
 Thanks again! 