### PR TITLE
(add) special makefile validation rules for .NOEXPORT

### DIFF
--- a/mbake/core/rules/special_target_validation.py
+++ b/mbake/core/rules/special_target_validation.py
@@ -57,6 +57,7 @@ class SpecialTargetValidationRule(FormatterPlugin):
             ".INTERMEDIATE": {"duplicatable": True, "requires_prereqs": False},
             ".SECONDARY": {"duplicatable": True, "requires_prereqs": False},
             ".DELETE_ON_ERROR": {"duplicatable": False, "requires_prereqs": False},
+            ".NOEXPORT": {"duplicatable": False, "requires_prereqs": False},
             ".IGNORE": {"duplicatable": True, "requires_prereqs": True},
             ".SILENT": {"duplicatable": True, "requires_prereqs": True},
             ".POSIX": {"duplicatable": False, "requires_prereqs": False},

--- a/tests/fixtures/special_targets/expected.mk
+++ b/tests/fixtures/special_targets/expected.mk
@@ -6,6 +6,7 @@
 # Note: .EXPORT_ALL_VARIABLES conflicts with .POSIX, so it's omitted
 .NOTPARALLEL:
 .ONESHELL:
+.NOEXPORT:
 
 # Declarative targets (can be duplicated)
 .PHONY: all clean

--- a/tests/fixtures/special_targets/input.mk
+++ b/tests/fixtures/special_targets/input.mk
@@ -6,6 +6,7 @@
 # Note: .EXPORT_ALL_VARIABLES conflicts with .POSIX, so it's omitted
 .NOTPARALLEL:
 .ONESHELL:
+.NOEXPORT:
 
 # Declarative targets (can be duplicated)
 .PHONY: all clean

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1622,3 +1622,20 @@ class TestSpecialTargets:
 
             assert not errors
             assert formatted_lines == expected_lines
+
+    def test_noexport_special_target(self):
+        """Test that .NOEXPORT is recognized as a valid special target."""
+        config = create_conservative_config()
+        formatter = MakefileFormatter(config)
+
+        input_lines = [
+            ".NOEXPORT:",
+            "",
+            "all:",
+            "\t@echo done",
+        ]
+
+        formatted_lines, errors, warnings = formatter.format_lines(input_lines)
+
+        assert not errors
+        assert formatted_lines == input_lines


### PR DESCRIPTION
For whatever reason `autotool` generate Makefile with `.NOEXPORT` .
```
# Tell versions [3.59,3.63) of GNU make to not export all variables.
# Otherwise a system limit (for SysV at least) may be exceeded.
.NOEXPORT:
```

It seem to be a legacy gnu extension, but 🤷🏽  support was easy to add! 

But feel free to close it, if you don't want to support it 