### PR TITLE
Update the "mbake init" cli call

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -163,7 +163,7 @@ def init(
     ),
 ) -> None:
     """Initialize configuration file with defaults."""
-    config_path = config_file or Path.home() / ".bake.toml"
+    config_path = config_file or Config.default_config_path()
 
     command_name = get_command_name()
     if config_path.exists() and not force:

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -93,6 +93,19 @@ class Config:
 
         return Path.home() / ".config" / "bake.toml"
 
+    @staticmethod
+    def default_config_path() -> Path:
+        """Return the default path for creating a new config file.
+
+        Order of preference:
+          1. $XDG_CONFIG_HOME/bake.toml — if $XDG_CONFIG_HOME is set.
+          2. ~/.config/bake.toml — XDG default.
+        """
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        if xdg_config_home:
+            return Path(xdg_config_home) / "bake.toml"
+        return Path.home() / ".config" / "bake.toml"
+
     @classmethod
     def load(cls, config_path: Optional[Path] = None) -> "Config":
         """Load configuration from XDG config path


### PR DESCRIPTION
Update the mbake cli call ```init``` to default to XDG_CONFIG_HOME for new config files. I forgot to update this with my previous set of commits, apologies for that.

Made a new function in the Config dataclass, this method determines where the config file should be saved, and it checks if the XDG_CONFIG_HOME environment variable is set, if it is we use it, else we default to ~/.config/bake.toml, which my previous commits already check for.

All tests and linting passes on my own branch as can be seen here - https://github.com/Ren-B-7/bake/actions/runs/24318873181