### PR TITLE
(Fix): Cli usage isnt fully standard and implemented

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -390,7 +390,7 @@ def validate(
                     tmp_path.unlink()
 
             if any_errors:
-                raise typer.Exit(1)
+                raise typer.Exit(2)
             return
 
         # Validate that files are provided when not using stdin
@@ -435,8 +435,11 @@ def validate(
                 )
 
         if any_errors:
-            raise typer.Exit(1)
+            raise typer.Exit(2)
 
+    except typer.Exit:
+        # Re-raise typer exits without wrapping them
+        raise
     except Exception as e:
         console.print(f"[red]Fatal error:[/red] {e}")
         raise typer.Exit(2) from e

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -324,12 +324,17 @@ def config(
 
 @app.command()
 def validate(
-    files: list[Path] = typer.Argument(..., help="Makefile(s) to validate."),
+    files: list[Path] = typer.Argument(
+        None, help="Makefile(s) to validate (not needed with --stdin)."
+    ),
     config_file: Optional[Path] = typer.Option(
         None, "--config", help="Path to configuration file."
     ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose output."
+    ),
+    stdin: bool = typer.Option(
+        False, "--stdin", help="Read from stdin and validate syntax."
     ),
 ) -> None:
     """Validate Makefile syntax using GNU make."""
@@ -341,6 +346,59 @@ def validate(
         )  # Just check config is valid
 
         any_errors = False
+
+        # Handle stdin mode
+        if stdin:
+            if files:
+                console.print(
+                    "[red]Error:[/red] Cannot specify files when using --stdin"
+                )
+                raise typer.Exit(1)
+
+            import sys
+            import tempfile
+
+            content = sys.stdin.read()
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".mk", delete=False
+            ) as tmp_file:
+                tmp_file.write(content)
+                tmp_path = Path(tmp_file.name)
+
+            try:
+                result = subprocess.run(
+                    ["make", "-f", str(tmp_path), "--dry-run", "--just-print"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+
+                if result.returncode == 0:
+                    if verbose:
+                        console.print("[green]✓[/green] stdin: Valid syntax")
+                else:
+                    if result.stderr:
+                        # Clean up error message to refer to 'stdin' instead of temp path
+                        error_msg = result.stderr.strip().replace(
+                            str(tmp_path), "stdin"
+                        )
+                        console.print(f"[red]✗[/red] stdin: Invalid syntax")
+                        console.print(f"  [dim]{escape(error_msg)}[/dim]")
+                    any_errors = True
+            finally:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+
+            if any_errors:
+                raise typer.Exit(1)
+            return
+
+        # Validate that files are provided when not using stdin
+        if not files:
+            console.print(
+                "[red]Error:[/red] No files specified. Use --stdin to read from stdin or provide file paths."
+            )
+            raise typer.Exit(1)
 
         for file_path in files:
             if not file_path.exists():

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -382,7 +382,7 @@ def validate(
                         error_msg = result.stderr.strip().replace(
                             str(tmp_path), "stdin"
                         )
-                        console.print(f"[red]✗[/red] stdin: Invalid syntax")
+                        console.print("[red]✗[/red] stdin: Invalid syntax")
                         console.print(f"  [dim]{escape(error_msg)}[/dim]")
                     any_errors = True
             finally:

--- a/tests/test_validate_command.py
+++ b/tests/test_validate_command.py
@@ -142,3 +142,70 @@ class TestValidateCommand:
         finally:
             Path(makefile1_path).unlink()
             Path(makefile2_path).unlink()
+
+    def test_validate_stdin_basic(self, runner):
+        """Test basic stdin validation functionality."""
+        input_content = "target:\n\techo 'hello'\n"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+
+            result = runner.invoke(app, ["validate", "--stdin"], input=input_content)
+
+            assert result.exit_code == 0
+            # By default verbose=False, so no "Valid" message for stdin
+            assert result.stdout == ""
+            mock_run.assert_called_once()
+
+            # Check that it used a temp file and cleaned it up
+            args = mock_run.call_args[0][0]
+            assert args[0] == "make"
+            assert args[1] == "-f"
+            assert args[2].endswith(".mk")
+
+    def test_validate_stdin_with_verbose(self, runner):
+        """Test stdin validation with --verbose flag."""
+        input_content = "target:\n\techo 'hello'\n"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+
+            result = runner.invoke(
+                app, ["validate", "--stdin", "--verbose"], input=input_content
+            )
+
+            assert result.exit_code == 0
+            assert "Valid" in result.stdout
+            assert "stdin" in result.stdout
+
+    def test_validate_stdin_with_errors(self, runner):
+        """Test stdin validation with syntax errors."""
+        input_content = "target:\necho 'missing tab'\n"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 2
+            mock_run.return_value.stderr = "Makefile:2: *** missing separator.  Stop."
+
+            result = runner.invoke(app, ["validate", "--stdin"], input=input_content)
+
+            assert result.exit_code == 2
+            assert "Invalid" in result.stdout
+            assert "stdin" in result.stdout
+            assert "missing separator" in result.stdout
+
+    def test_validate_stdin_cannot_specify_files(self, runner):
+        """Test that --stdin cannot be used with file arguments."""
+        result = runner.invoke(app, ["validate", "--stdin", "Makefile"])
+
+        assert result.exit_code == 1
+        assert "Cannot specify files when using --stdin" in result.stdout
+
+    def test_validate_requires_files_or_stdin(self, runner):
+        """Test that validate command requires either files or --stdin."""
+        result = runner.invoke(app, ["validate"])
+
+        assert result.exit_code == 1
+        assert "No files specified" in result.stdout
+        assert "Use --stdin" in result.stdout


### PR DESCRIPTION
Tried to implement a reformatter and a flymake tool for emacs, however the --stdin command wasnt fully working to the level that it would need to, and had to take a few revisions. Compared to how some other tools handle their --stdin and how some lsps handle --stdin reading for formatting and linting. And updated the cli.py file accordingly.

Also added more tests to ensure the cli is working as it should.

All new and old tests are passing, tests ran on my local branch here: https://github.com/Ren-B-7/bake/actions/runs/24457990738/job/71463898552