### PR TITLE
(feat): Configurable timeout on syntax checks

### DIFF
--- a/.bake.toml.example
+++ b/.bake.toml.example
@@ -6,6 +6,9 @@
 debug = false
 verbose = false
 
+# Timeout used for syntax checking with 'make -f'
+syntax_check_timeout = 10
+
 # Error message formatting
 gnu_error_format = true
 wrap_error_messages = false

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ mbake update                            # Update to latest version
 - `--diff`: Show what changes would be made
 - `--backup`: Create backup before formatting
 - `--validate`: Validate syntax after formatting
+- `--timeout`: Timeout to use for syntax checks
 - `--config`: Use custom configuration file
 
 ## Configuration

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -376,7 +376,7 @@ def validate(
                 console.print(f"[yellow]?[/yellow] {file_path}: Validation timed out")
             except FileNotFoundError:
                 console.print(
-                    f"[yellow]?[/yellow] {file_path}: make not found - skipping syntax validation"
+                    f"[yellow]?[/yellow] {file_path}: 'make' not found - skipping syntax validation"
                 )
 
         if any_errors:

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -104,6 +104,9 @@ DEFAULT_CONFIG = """# mbake configuration file
 debug = false
 verbose = false
 
+# Timeout used for syntax checking with 'make -f'
+syntax_check_timeout = 10
+
 # Error message formatting
 gnu_error_format = true
 wrap_error_messages = false
@@ -336,7 +339,7 @@ def validate(
     setup_logging(verbose)
 
     try:
-        Config.load_or_default(
+        config = Config.load_or_default(
             config_file, explicit=config_file is not None
         )  # Just check config is valid
 
@@ -357,7 +360,7 @@ def validate(
                     ["make", "-f", makefile_name, "--dry-run", "--just-print"],
                     capture_output=True,
                     text=True,
-                    timeout=10,
+                    timeout=config.syntax_check_timeout,
                     cwd=makefile_dir,
                 )
 
@@ -373,7 +376,7 @@ def validate(
                 console.print(f"[yellow]?[/yellow] {file_path}: Validation timed out")
             except FileNotFoundError:
                 console.print(
-                    f"[yellow]?[/yellow] {file_path}: 'make' not found - skipping syntax validation"
+                    f"[yellow]?[/yellow] {file_path}: {file_path.name} not found - skipping syntax validation"
                 )
 
         if any_errors:
@@ -402,6 +405,9 @@ def format(
         False, "--verbose", "-v", help="Enable verbose output."
     ),
     debug: bool = typer.Option(False, "--debug", help="Enable debug output."),
+    syntax_check_timeout: int = typer.Option(
+        10, "--timeout", help="Set timeout for Makefile syntax check"
+    ),
     config_file: Optional[Path] = typer.Option(
         None, "--config", help="Path to configuration file (default: ~/.bake.toml)."
     ),
@@ -423,6 +429,9 @@ def format(
         config = Config.load_or_default(config_file, explicit=config_file is not None)
         config.verbose = verbose or config.verbose
         config.debug = debug or config.debug
+        config.syntax_check_timeout = (
+            syntax_check_timeout or config.syntax_check_timeout
+        )
 
         # Get appropriately configured console
         output_console = get_console(config)
@@ -611,14 +620,18 @@ def format(
                                     ["make", "-f", str(file_path), "--dry-run"],
                                     capture_output=True,
                                     text=True,
-                                    timeout=5,
+                                    timeout=config.syntax_check_timeout,
                                 )
                                 if proc.returncode != 0:
                                     output_console.print(
                                         "[red]Warning:[/red] Formatted file has syntax errors"
                                     )
                                     any_errors = True
-                            except (subprocess.TimeoutExpired, FileNotFoundError):
+                            except (
+                                subprocess.TimeoutExpired,
+                                subprocess.CalledProcessError,
+                                FileNotFoundError,
+                            ):
                                 pass  # Skip validation if make not available
 
                 elif verbose:
@@ -636,10 +649,9 @@ def format(
         # Exit with appropriate code
         if any_errors:
             raise typer.Exit(2)  # Error
-        elif check and any_changed:
+        if check and any_changed:
             raise typer.Exit(1)  # Check failed
-        else:
-            return  # Success
+        return  # Success
 
     except FileNotFoundError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -376,7 +376,7 @@ def validate(
                 console.print(f"[yellow]?[/yellow] {file_path}: Validation timed out")
             except FileNotFoundError:
                 console.print(
-                    f"[yellow]?[/yellow] {file_path}: {file_path.name} not found - skipping syntax validation"
+                    f"[yellow]?[/yellow] {file_path}: make not found - skipping syntax validation"
                 )
 
         if any_errors:
@@ -629,7 +629,6 @@ def format(
                                     any_errors = True
                             except (
                                 subprocess.TimeoutExpired,
-                                subprocess.CalledProcessError,
                                 FileNotFoundError,
                             ):
                                 pass  # Skip validation if make not available

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -66,6 +66,8 @@ class Config:
     formatter: FormatterConfig
     debug: bool = False
     verbose: bool = False
+    # Timeout used for make file syntax checking
+    syntax_check_timeout = 10
     # Error message formatting
     gnu_error_format: bool = (
         True  # Use GNU standard error format (file:line: Error: message)
@@ -147,6 +149,8 @@ class Config:
             global_data["debug"] = data["debug"]
         if "verbose" in data:
             global_data["verbose"] = data["verbose"]
+        if "timeout_seconds" in data:
+            global_data["timeout_seconds"] = data["timeout_seconds"]
         if "gnu_error_format" in data:
             global_data["gnu_error_format"] = data["gnu_error_format"]
         if "wrap_error_messages" in data:
@@ -220,6 +224,7 @@ class Config:
             },
             "debug": self.debug,
             "verbose": self.verbose,
+            "syntax_check_timeout": self.syntax_check_timeout,
             "gnu_error_format": self.gnu_error_format,
             "wrap_error_messages": self.wrap_error_messages,
         }


### PR DESCRIPTION
Added a new config item, ```syntax_check_timeout```, since ```timeout``` would be misleading.

This sets the timeout used for ```subprocess.run``` calls that are used to ensure the syntax of files are valid.

This commit adds the config option, command line override, and timeout to the subprocess.run code. The default for this timeout is 10 seconds.

This has not yet been added to the package.json for vscode extensions.

All tests are passing on my local branch, formatting and linting has been taken care of as well: https://github.com/Ren-B-7/bake/actions/runs/24462666087