### PR TITLE
(Feat): add option to indent continuation lines

### DIFF
--- a/.bake.toml.example
+++ b/.bake.toml.example
@@ -40,6 +40,11 @@ indent_nested_conditionals = false
 # Indentation settings
 tab_width = 2
 
+# Recipe continuation indentation style
+# "align"  - continuation lines adopt the indentation of the first continuation line (default)
+# "indent" - continuation lines are indented by one tab plus tab_width spaces
+recipe_continuation_indent = "align"
+
 # Variable alignment
 align_variable_assignments = false      # Align consecutive assignments
 align_across_comments = false           # Continue alignment across comments

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -52,6 +52,11 @@ indent_nested_conditionals = false
 # Indentation settings
 tab_width = 2
 
+# Recipe continuation indentation style
+# "align"  - continuation lines adopt the indentation of the first continuation line (default)
+# "indent" - continuation lines are indented by one tab plus tab_width spaces
+recipe_continuation_indent = "align"
+
 # Variable alignment settings
 align_variable_assignments = false
 align_across_comments = false

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ normalize_line_continuations = true     # Clean up backslash continuations
 remove_trailing_whitespace = true       # Remove trailing spaces
 fix_missing_recipe_tabs = true          # Convert spaces to tabs in recipes
 
+# Recipe continuation indentation (default: "align")
+# "align"  – continuation lines keep the indentation of the first continuation line
+# "indent" – continuation lines are indented by one tab + tab_width spaces,
+#            making sub-arguments visually distinct from the command
+recipe_continuation_indent = "align"
+
 # Variable alignment
 align_variable_assignments = false      # Align consecutive assignments
 align_across_comments = false           # Continue alignment across comments
@@ -136,6 +142,42 @@ Enable auto-insertion in your config:
 [formatter]
 auto_insert_phony_declarations = true
 ```
+
+## Recipe Continuation Indentation
+
+Control how continuation lines inside recipes are indented with `recipe_continuation_indent`.
+
+**`"align"` (default)** — continuation lines follow the indentation of the first continuation line (current behaviour):
+
+<!-- markdownlint-disable MD010 -->
+```makefile
+benchmark:
+	uv run benchmark code-eval \
+	--extract-scripts \
+	--chat-model=gpt-5.2
+```
+<!-- markdownlint-enable MD010 -->
+
+**`"indent"`** — continuation lines receive one extra level of indentation (`tab_width` spaces) so that sub-arguments are visually distinct from the command:
+
+<!-- markdownlint-disable MD010 -->
+```makefile
+benchmark:
+	uv run benchmark code-eval \
+	  --extract-scripts \
+	  --chat-model=gpt-5.2
+```
+<!-- markdownlint-enable MD010 -->
+
+Enable in your config:
+
+```toml
+[formatter]
+recipe_continuation_indent = "indent"
+tab_width = 2  # Controls how many extra spaces are added
+```
+
+> **Note:** Variable-assignment continuations and recipe blocks containing shell control structures (`if`/`for`/`while`/…) are not affected by this setting.
 
 ## Examples
 

--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -138,6 +138,11 @@ indent_nested_conditionals = false
 # Indentation settings
 tab_width = 2
 
+# Recipe continuation indentation style
+# "align"  - continuation lines adopt the indentation of the first continuation line (default)
+# "indent" - continuation lines are indented by one tab plus tab_width spaces
+recipe_continuation_indent = "align"
+
 # Variable alignment settings
 align_variable_assignments = false
 align_across_comments = false
@@ -297,6 +302,11 @@ def config(
                 "Indent nested conditionals",
             ),
             ("tab_width", config.formatter.tab_width, "Tab width in spaces"),
+            (
+                "recipe_continuation_indent",
+                config.formatter.recipe_continuation_indent,
+                "Recipe continuation indent style (align|indent)",
+            ),
             (
                 "align_variable_assignments",
                 config.formatter.align_variable_assignments,

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -54,6 +54,13 @@ class FormatterConfig:
     # Indentation settings
     tab_width: int = 2
 
+    # Recipe continuation indentation style
+    # "align"  – continuation lines adopt the indentation of the first continuation
+    #            line (current / default behaviour).
+    # "indent" – continuation lines are indented by one tab plus tab_width spaces,
+    #            giving sub-arguments a visually distinct extra level of indentation.
+    recipe_continuation_indent: str = "align"
+
     # Variable alignment settings
     align_variable_assignments: bool = False
     align_across_comments: bool = False
@@ -149,6 +156,7 @@ class Config:
             "tab_width",
             "align_variable_assignments",
             "align_across_comments",
+            "recipe_continuation_indent",
         }
         filtered_formatter_data = {
             k: v for k, v in formatter_data.items() if k in valid_formatter_keys
@@ -234,6 +242,7 @@ class Config:
                 "tab_width": self.formatter.tab_width,
                 "align_variable_assignments": self.formatter.align_variable_assignments,
                 "align_across_comments": self.formatter.align_across_comments,
+                "recipe_continuation_indent": self.formatter.recipe_continuation_indent,
             },
             "debug": self.debug,
             "verbose": self.verbose,

--- a/mbake/core/rules/continuation.py
+++ b/mbake/core/rules/continuation.py
@@ -21,6 +21,8 @@ class ContinuationRule(FormatterPlugin):
         warnings: list[str] = []
 
         normalize_continuations = config.get("normalize_line_continuations", True)
+        recipe_continuation_indent = config.get("recipe_continuation_indent", "align")
+        tab_width = config.get("tab_width", 2)
 
         if not normalize_continuations:
             return FormatResult(
@@ -53,7 +55,11 @@ class ContinuationRule(FormatterPlugin):
                     j += 1
 
                 # Format the continuation block
-                formatted_block = self._format_continuation_block(continuation_lines)
+                formatted_block = self._format_continuation_block(
+                    continuation_lines,
+                    recipe_continuation_indent=recipe_continuation_indent,
+                    tab_width=tab_width,
+                )
 
                 if formatted_block != continuation_lines:
                     changed = True
@@ -72,7 +78,12 @@ class ContinuationRule(FormatterPlugin):
             check_messages=[],
         )
 
-    def _format_continuation_block(self, lines: list[str]) -> list[str]:
+    def _format_continuation_block(
+        self,
+        lines: list[str],
+        recipe_continuation_indent: str = "align",
+        tab_width: int = 2,
+    ) -> list[str]:
         """Format a block of continuation lines."""
         if not lines:
             return lines
@@ -113,6 +124,13 @@ class ContinuationRule(FormatterPlugin):
                 leading_whitespace += char
             else:
                 break
+
+        # In "indent" mode, recipe continuation lines receive one tab plus
+        # tab_width spaces so that sub-arguments appear visually indented
+        # relative to the command on the first line.  Variable-assignment
+        # continuations always use the "align" (normalise-to-first-line) path.
+        if is_recipe and recipe_continuation_indent == "indent":
+            leading_whitespace = "\t" + " " * tab_width
 
         # Format all continuation lines (from second line onwards)
         for line in lines[1:]:

--- a/tests/fixtures/recipe_continuation_indent/expected.mk
+++ b/tests/fixtures/recipe_continuation_indent/expected.mk
@@ -1,0 +1,16 @@
+.PHONY: benchmark
+
+benchmark:
+	uv run benchmark code-eval \
+	  --extract-scripts \
+	  --chat-model=gpt-5.2
+
+build:
+	docker build \
+	  --no-cache \
+	  --tag=myimage:latest .
+
+# Variable assignment continuations are unaffected
+SOURCES = file1.c \
+          file2.c \
+          file3.c

--- a/tests/fixtures/recipe_continuation_indent/input.mk
+++ b/tests/fixtures/recipe_continuation_indent/input.mk
@@ -1,0 +1,16 @@
+.PHONY: benchmark
+
+benchmark:
+	uv run benchmark code-eval \
+	--extract-scripts \
+	--chat-model=gpt-5.2
+
+build:
+	docker build \
+	--no-cache \
+	--tag=myimage:latest .
+
+# Variable assignment continuations are unaffected
+SOURCES = file1.c \
+          file2.c \
+          file3.c

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -185,6 +185,121 @@ class TestContinuationRule:
         assert not result.changed
 
 
+class TestContinuationRuleIndentMode:
+    """Test recipe_continuation_indent = 'indent' mode."""
+
+    def test_recipe_continuation_indent_mode(self):
+        """In 'indent' mode, continuation lines get \\t + tab_width spaces."""
+        rule = ContinuationRule()
+        config = {
+            "normalize_line_continuations": True,
+            "max_line_length": 120,
+            "recipe_continuation_indent": "indent",
+            "tab_width": 2,
+        }
+        lines = [
+            "\tuv run benchmark code-eval \\",
+            "\t--extract-scripts \\",
+            "\t--chat-model=gpt-5.2",
+        ]
+
+        result = rule.format(lines, config)
+
+        assert result.changed
+        assert result.lines[0] == "\tuv run benchmark code-eval \\"
+        assert result.lines[1] == "\t  --extract-scripts \\"
+        assert result.lines[2] == "\t  --chat-model=gpt-5.2"
+
+    def test_recipe_continuation_indent_mode_tab_width_4(self):
+        """tab_width controls the extra space count in 'indent' mode."""
+        rule = ContinuationRule()
+        config = {
+            "normalize_line_continuations": True,
+            "max_line_length": 120,
+            "recipe_continuation_indent": "indent",
+            "tab_width": 4,
+        }
+        lines = [
+            "\tdocker build \\",
+            "\t--no-cache \\",
+            "\t--tag=myimage:latest .",
+        ]
+
+        result = rule.format(lines, config)
+
+        assert result.changed
+        assert result.lines[0] == "\tdocker build \\"
+        assert result.lines[1] == "\t    --no-cache \\"
+        assert result.lines[2] == "\t    --tag=myimage:latest ."
+
+    def test_variable_assignment_unaffected_by_indent_mode(self):
+        """Variable-assignment continuations are never affected by indent mode."""
+        rule = ContinuationRule()
+        config = {
+            "normalize_line_continuations": True,
+            "max_line_length": 120,
+            "recipe_continuation_indent": "indent",
+            "tab_width": 2,
+        }
+        # Variable assignment — first line does NOT start with a tab
+        lines = [
+            "SOURCES = file1.c \\",
+            "          file2.c \\",
+            "          file3.c",
+        ]
+
+        result = rule.format(lines, config)
+
+        # Alignment is preserved from the first continuation line (10 spaces)
+        assert result.lines[0] == "SOURCES = file1.c \\"
+        assert result.lines[1] == "          file2.c \\"
+        assert result.lines[2] == "          file3.c"
+
+    def test_align_mode_default_behaviour_unchanged(self):
+        """Default 'align' mode normalises continuation to first continuation line."""
+        rule = ContinuationRule()
+        config = {
+            "normalize_line_continuations": True,
+            "max_line_length": 120,
+            "recipe_continuation_indent": "align",
+            "tab_width": 2,
+        }
+        lines = [
+            "\tuv run benchmark code-eval \\",
+            "\t--extract-scripts \\",
+            "\t--chat-model=gpt-5.2",
+        ]
+
+        result = rule.format(lines, config)
+
+        # In align mode, continuation lines keep their original leading whitespace
+        # (the first continuation line starts with a single tab)
+        assert result.lines[1] == "\t--extract-scripts \\"
+        assert result.lines[2] == "\t--chat-model=gpt-5.2"
+
+    def test_shell_control_structures_bypass_indent_mode(self):
+        """Shell control-structure blocks are not reindented even in indent mode."""
+        rule = ContinuationRule()
+        config = {
+            "normalize_line_continuations": True,
+            "max_line_length": 120,
+            "recipe_continuation_indent": "indent",
+            "tab_width": 2,
+        }
+        lines = [
+            "\tif [ -f file ]; then \\",
+            "\t\techo found \\",
+            "\tfi",
+        ]
+
+        result = rule.format(lines, config)
+
+        # Shell-control path preserves original indentation regardless of mode
+        assert result.lines[0] == "\tif [ -f file ]; then \\"
+        assert result.lines[1] == "\t\techo found \\"
+        assert result.lines[2] == "\tfi"
+
+
 class TestPhonyRule:
     """Test the .PHONY declaration formatting rule."""
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -410,6 +410,24 @@ class TestLineContinuations:
 class TestPhonyTargets:
     """Test .PHONY target handling."""
 
+    def test_recipe_continuation_indent_fixture(self):
+        """recipe_continuation_indent='indent' applies extra indent to recipe continuations."""
+        config = create_conservative_config()
+        config.formatter.recipe_continuation_indent = "indent"
+        config.formatter.tab_width = 2
+        formatter = MakefileFormatter(config)
+
+        input_file = Path("tests/fixtures/recipe_continuation_indent/input.mk")
+        expected_file = Path("tests/fixtures/recipe_continuation_indent/expected.mk")
+
+        input_lines = input_file.read_text(encoding="utf-8").splitlines()
+        expected_lines = expected_file.read_text(encoding="utf-8").splitlines()
+
+        formatted_lines, errors, warnings = formatter.format_lines(input_lines)
+
+        assert not errors
+        assert formatted_lines == expected_lines
+
     def test_phony_targets_fixture(self):
         """Test phony targets fixture."""
         config = create_conservative_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -347,6 +347,7 @@ class TestToDict:
             "tab_width",
             "align_variable_assignments",
             "align_across_comments",
+            "recipe_continuation_indent",
         }
         assert keys == expected
 


### PR DESCRIPTION
Add `recipe_continuation_indent` config option for recipe continuation indentation

- New config setting: `recipe_continuation_indent = "align" | "indent"` (default: `"align"`)
- `"indent"` mode indents recipe continuation lines by `\t` + `tab_width` spaces for visual distinction
- `"align"` mode (default) preserves existing normalization behavior
- Variable-assignment and shell-control-structure continuations unaffected
- Includes unit tests, fixture tests, and documentation