### PR TITLE
(Fix): ensure defaults wo config match default 'make init'

### DIFF
--- a/mbake/config.py
+++ b/mbake/config.py
@@ -44,7 +44,7 @@ class FormatterConfig:
 
     # General settings
     remove_trailing_whitespace: bool = True
-    ensure_final_newline: bool = False
+    ensure_final_newline: bool = True
     normalize_empty_lines: bool = True
     max_consecutive_empty_lines: int = 2
     fix_missing_recipe_tabs: bool = True

--- a/tests/fixtures/comment_only_targets/expected.mk
+++ b/tests/fixtures/comment_only_targets/expected.mk
@@ -31,3 +31,4 @@ help:
 debug: ## Build with debug symbols
 release: ## Build optimized version
 package: ## Create distribution package
+

--- a/tests/fixtures/shell_operators/expected.mk
+++ b/tests/fixtures/shell_operators/expected.mk
@@ -44,3 +44,4 @@ install: all
 
 install-files:
 	install -m755 $(TARGET) $(DESTDIR)$(bindir)/
+

--- a/tests/fixtures/whitespace_normalization/expected.mk
+++ b/tests/fixtures/whitespace_normalization/expected.mk
@@ -10,3 +10,4 @@ clean:
 
 install:
 	cp $(TARGET) /usr/local/bin/
+


### PR DESCRIPTION
fixes a config consistency bug by aligning ensure_final_newline defaults with generated init config. This fixes #101 