### PR TITLE
Extend and refactor the logic of finding a config file

### DIFF
--- a/mbake/cli.py
+++ b/mbake/cli.py
@@ -199,28 +199,17 @@ def init(
 @app.command()
 def config(
     show_path: bool = typer.Option(False, "--path", help="Show config file path."),
-    config_file: Optional[Path] = typer.Option(
+    config_path: Optional[Path] = typer.Option(
         None, "--config", help="Path to configuration file."
     ),
 ) -> None:
     """Show current configuration."""
-    config_path = config_file or Config.determine_config_path()
-
-    if show_path:
-        console.print(str(config_path))
-        return
-
-    command_name = get_command_name()
-    if not config_path.exists():
-        console.print(f"[red]Configuration file not found at {config_path}[/red]")
-        console.print(
-            f"Run [bold]{command_name} init[/bold] to create one with defaults"
-        )
-        raise typer.Exit(1)
-
     try:
-        config = Config.load(config_file)
-        console.print(f"[bold]Configuration from {config_path}[/bold]\n")
+        config, actual_config_path = Config.load(config_path)
+        if show_path:
+            console.print(actual_config_path)
+            return
+        console.print(f"[bold]Configuration from {actual_config_path}[/bold]\n")
 
         # Display config settings
         console.print("[bold cyan]Formatter Settings:[/bold cyan]")
@@ -319,7 +308,15 @@ def config(
         console.print(f"  verbose: {config.verbose}")
         console.print(f"  gnu_error_format: {config.gnu_error_format}")
         console.print(f"  wrap_error_messages: {config.wrap_error_messages}")
-
+    except FileNotFoundError as e:
+        if config_path is None:
+            console.print("[red]Configuration file not found[/red]")
+        else:
+            console.print(f"[red]Configuration file not found at {config_path}[/red]")
+        console.print(
+            f"Run [bold]{get_command_name()} init[/bold] to create one with defaults"
+        )
+        raise typer.Exit(1) from e
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to load config: {e}")
         raise typer.Exit(1) from e
@@ -330,7 +327,7 @@ def validate(
     files: list[Path] = typer.Argument(
         None, help="Makefile(s) to validate (not needed with --stdin)."
     ),
-    config_file: Optional[Path] = typer.Option(
+    config_path: Optional[Path] = typer.Option(
         None, "--config", help="Path to configuration file."
     ),
     verbose: bool = typer.Option(
@@ -344,9 +341,8 @@ def validate(
     setup_logging(verbose)
 
     try:
-        config = Config.load_or_default(
-            config_file, explicit=config_file is not None
-        )  # Just check config is valid
+        # Validate the config and use it later
+        config = Config.load_or_default(config_path)[0]
 
         any_errors = False
 
@@ -469,7 +465,7 @@ def format(
     syntax_check_timeout: int = typer.Option(
         10, "--timeout", help="Set timeout for Makefile syntax check"
     ),
-    config_file: Optional[Path] = typer.Option(
+    config_path: Optional[Path] = typer.Option(
         None,
         "--config",
         help="Path to configuration file (default: {XDG_CONFIG_HOME}/bake.toml).",
@@ -489,7 +485,7 @@ def format(
 
     try:
         # Load configuration with fallback to defaults
-        config = Config.load_or_default(config_file, explicit=config_file is not None)
+        config = Config.load_or_default(config_path)[0]
         config.verbose = verbose or config.verbose
         config.debug = debug or config.debug
         config.syntax_check_timeout = (

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -96,7 +96,7 @@ class Config:
         ) -> Optional[Path]:
             filepath = starting_directory / filename
             while not filepath.exists():
-                if filepath.parent != Path(filepath.root):
+                if filepath.parent == Path(filepath.root):
                     return None
                 filepath = filepath.parent.parent / filename
             return filepath

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -77,31 +77,59 @@ class Config:
     )
 
     @staticmethod
-    def determine_config_path() -> Path:
-        """Return the XDG config path for mbake.
+    def determine_config_path() -> Optional[Path]:
+        """Look for mbake's config in common places.
 
-        Order of options:
-          1. `~/.bake.toml — if the file exists
-          2. `$XDG_CONFIG_HOME/bake.toml' — if `$XDG_CONFIG_HOME' is set.
-          3. `~/.config/bake.toml — XDG default.
+        Search scheme:
+          1. ``./.bake.toml``, then ``../.bake.toml``, then ``../../.bake.toml``,
+            etc. until ``/`` is hit.
+          2. ``~/.bake.toml``.
+          3. ``$XDG_CONFIG_HOME/bake.toml`` — if ``$XDG_CONFIG_HOME`` is set.
+          4. ``~/.config/bake.toml`` — XDG default.
+
+        Returns:
+            Path to the config file, or None if it wasn't found.
         """
-        home_path = Path.home() / ".bake.toml"
-        if home_path.exists():
-            return home_path
 
-        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
-        if xdg_config_home:
-            return Path(xdg_config_home) / "bake.toml"
+        def find_file_in_ancestor_directories(
+            filename: str, starting_directory: Path
+        ) -> Optional[Path]:
+            filepath = starting_directory / filename
+            while not filepath.exists():
+                if filepath.parent != Path(filepath.root):
+                    return None
+                filepath = filepath.parent.parent / filename
+            return filepath
 
-        return Path.home() / ".config" / "bake.toml"
+        resolved_config_path = find_file_in_ancestor_directories(
+            ".bake.toml", Path.cwd()
+        )
+        if resolved_config_path is not None:
+            return resolved_config_path
+
+        resolved_config_path = Path.home() / ".bake.toml"
+        if resolved_config_path.exists():
+            return resolved_config_path
+
+        resolved_config_path = (
+            Path(os.environ.get("XDG_CONFIG_HOME", "").strip()) / "bake.toml"
+        )
+
+        if resolved_config_path.exists():
+            return resolved_config_path
+
+        resolved_config_path = Path.home() / ".config" / "bake.toml"
+        if resolved_config_path.exists():
+            return resolved_config_path
+        return None
 
     @staticmethod
     def default_config_path() -> Path:
         """Return the default path for creating a new config file.
 
         Order of preference:
-          1. $XDG_CONFIG_HOME/bake.toml — if $XDG_CONFIG_HOME is set.
-          2. ~/.config/bake.toml — XDG default.
+          1. ``$XDG_CONFIG_HOME/bake.toml`` — if ``$XDG_CONFIG_HOME`` is set.
+          2. ``~/.config/bake.toml`` — XDG default.
         """
         xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
         if xdg_config_home:
@@ -109,23 +137,36 @@ class Config:
         return Path.home() / ".config" / "bake.toml"
 
     @classmethod
-    def load(cls, config_path: Optional[Path] = None) -> "Config":
-        """Load configuration from XDG config path
-        ( Checks if home config exists, else checks if XDG_CONFIG_HOME exists,
-         else falls back to ~/.config/bake.toml)"""
-        if config_path is None:
+    def load(cls, config_path: Optional[Path] = None) -> tuple["Config", Path]:
+        """Attempt to load configuration from ``config_path``,
+        or from the default places if ``config_path`` is None.
+
+        Returns:
+            The loaded config and the path it's at.
+
+        Raises:
+            FileNotFoundError: If ``config_path` wasn't found or, when ``config_path`` is None,
+                if the config wasn't found at the default places.
+            ValueError: If the config was found but its parsing failed.
+        """
+        if (
+            config_path is not None and not config_path.exists()
+        ):  # Bail out if a nonexistent config was passed
+            raise FileNotFoundError(f"Configuration file not found at {config_path}")
+        if (
+            config_path is None
+        ):  # If config wasn't explicitly passed, look for it in common places
             config_path = cls.determine_config_path()
-
-        if not config_path.exists():
+        if config_path is None:  # Still nothing?
             raise FileNotFoundError(
-                f"Configuration file not found at {config_path}. "
-                "Please create ~/.config/bake.toml with your formatting preferences."
+                "Configuration file not found at the default places. "
+                "Please create .bake.toml in your project's root or "
+                "~/.config/bake.toml with your formatting preferences."
             )
-
         try:
             with open(config_path, "rb") as f:
                 data = tomllib.load(f)
-        except Exception as e:
+        except tomllib.TOMLDecodeError as e:
             raise ValueError(f"Failed to parse configuration file: {e}") from e
 
         # Extract formatter config, filtering out non-FormatterConfig keys
@@ -168,50 +209,23 @@ class Config:
             global_data["gnu_error_format"] = data["gnu_error_format"]
         if "wrap_error_messages" in data:
             global_data["wrap_error_messages"] = data["wrap_error_messages"]
-
-        return cls(formatter=formatter_config, **global_data)
+        return cls(formatter=formatter_config, **global_data), config_path
 
     @classmethod
     def load_or_default(
-        cls, config_path: Optional[Path] = None, explicit: bool = False
-    ) -> "Config":
-        """Load config or return defaults if not found.
-
-        Args:
-            config_path: Path to config file, or None for default
-            explicit: True if config_path was explicitly specified by user
-        """
-        if config_path is not None:
-            # User explicitly specified a config file
-            try:
-                return cls.load(config_path)
-            except FileNotFoundError:
-                if explicit:
-                    raise
-                return cls(formatter=FormatterConfig())
-
-        # Try to find config file in current directory first, then xdg_config
-        # directory
-
-        current_dir_config = Path.cwd() / ".bake.toml"
-        xdg_home_config = cls.determine_config_path()
-
-        if current_dir_config.exists():
-            try:
-                return cls.load(current_dir_config)
-            except Exception:
-                # If current directory config is invalid, fall back to home directory
-                pass
-
-        if xdg_home_config.exists():
-            try:
-                return cls.load(xdg_home_config)
-            except Exception:
-                # If home directory config is invalid, fall back to defaults
-                pass
-
-        # Return default configuration if no config file found
-        return cls(formatter=FormatterConfig())
+        cls, config_path: Optional[Path] = None
+    ) -> tuple["Config", Optional[Path]]:
+        """Like ``load`` but falls back to the default configuration
+        if the config file isn't present at the default locations"""
+        try:
+            return cls.load(config_path)
+        except FileNotFoundError:
+            if config_path is None:  # Config wasn't found at the default places
+                return cls(formatter=FormatterConfig()), None
+            # Config was passed explicitly but wasn't found. Tell the caller about that
+            raise
+        # Don't handle `ValueError`
+        # Tell the caller that they have an invalid config
 
     def to_dict(self) -> dict[str, Any]:
         """Convert config to dictionary."""

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -145,7 +145,7 @@ class Config:
             The loaded config and the path it's at.
 
         Raises:
-            FileNotFoundError: If ``config_path` wasn't found or, when ``config_path`` is None,
+            FileNotFoundError: If ``config_path`` wasn't found or, when ``config_path`` is None,
                 if the config wasn't found at the default places.
             ValueError: If the config was found but its parsing failed.
         """

--- a/mbake/config.py
+++ b/mbake/config.py
@@ -111,12 +111,11 @@ class Config:
         if resolved_config_path.exists():
             return resolved_config_path
 
-        resolved_config_path = (
-            Path(os.environ.get("XDG_CONFIG_HOME", "").strip()) / "bake.toml"
-        )
-
-        if resolved_config_path.exists():
-            return resolved_config_path
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        if xdg_config_home:
+            resolved_config_path = Path(xdg_config_home) / "bake.toml"
+            if resolved_config_path.exists():
+                return resolved_config_path
 
         resolved_config_path = Path.home() / ".config" / "bake.toml"
         if resolved_config_path.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI functionality."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -37,7 +38,9 @@ class TestCLIFormat:
             "target:\n\techo hello"  # No phony insertion, no final newline
         )
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input=input_content)
 
         assert result.exit_code == 0
@@ -48,7 +51,9 @@ class TestCLIFormat:
         input_content = "target1:\n\techo hello\ntarget2:\n\techo world"
         expected_content = "target1:\n\techo hello\ntarget2:\n\techo world"  # No phony insertion, no final newline
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input=input_content)
 
         assert result.exit_code == 0
@@ -59,7 +64,9 @@ class TestCLIFormat:
         # This should trigger some formatting rules that might cause errors
         input_content = "target:\necho hello"  # Missing tab for recipe
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input=input_content)
 
         # Should still format but might have warnings/errors
@@ -71,7 +78,9 @@ class TestCLIFormat:
         """Test stdin formatting with --check flag."""
         input_content = "target:\n\techo hello"
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(
                 app, ["format", "--stdin", "--check"], input=input_content
             )
@@ -87,7 +96,9 @@ class TestCLIFormat:
             "target:\n\techo hello"  # No phony insertion, no final newline
         )
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(
                 app, ["format", "--stdin", "--verbose"], input=input_content
             )
@@ -97,7 +108,9 @@ class TestCLIFormat:
 
     def test_format_stdin_cannot_specify_files(self, runner, test_config):
         """Test that --stdin cannot be used with file arguments."""
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin", "Makefile"])
 
         assert result.exit_code == 1
@@ -105,7 +118,9 @@ class TestCLIFormat:
 
     def test_format_requires_files_or_stdin(self, runner, test_config):
         """Test that format command requires either files or --stdin."""
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format"])
 
         assert result.exit_code == 1
@@ -114,7 +129,9 @@ class TestCLIFormat:
 
     def test_format_stdin_preserves_empty_input(self, runner, test_config):
         """Test that stdin formatting handles empty input gracefully."""
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input="")
 
         assert result.exit_code == 0
@@ -137,7 +154,9 @@ main.o: main.c
 \t$(CC) $(CFLAGS) -c main.c
 """
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input=input_content)
 
         assert result.exit_code == 0
@@ -153,7 +172,9 @@ main.o: main.c
         # Create input that might cause errors
         input_content = "target:\necho hello"  # Missing tab
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(app, ["format", "--stdin"], input=input_content)
 
         # Should still succeed but might have warnings
@@ -165,7 +186,9 @@ main.o: main.c
         """Test that --diff flag works with --stdin."""
         input_content = "target:\n\techo hello"
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(
                 app, ["format", "--stdin", "--diff"], input=input_content
             )
@@ -182,7 +205,9 @@ main.o: main.c
             "target:\n\techo hello"  # No phony insertion, no final newline
         )
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(
                 app, ["format", "--stdin", "--backup"], input=input_content
             )
@@ -197,7 +222,9 @@ main.o: main.c
             "target:\n\techo hello"  # No phony insertion, no final newline
         )
 
-        with patch("mbake.cli.Config.load_or_default", return_value=test_config):
+        with patch(
+            "mbake.cli.Config.load_or_default", return_value=(test_config, Path())
+        ):
             result = runner.invoke(
                 app, ["format", "--stdin", "--validate"], input=input_content
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,14 +6,19 @@ Run from the project root:
 """
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import tomllib
 
 from mbake.config import Config, FormatterConfig
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import tomllib
 
 from mbake.config import Config, FormatterConfig
 
@@ -248,6 +249,26 @@ class TestLoadOrDefault:
                 result = Config.load_or_default()[0]
         assert result.formatter.tab_width == 7
 
+    def test_ancestor_directories_are_searched(self):
+        """All ancestor directories of CWD are searched for a .bake.toml, not just the CWD.
+        Moreover, the deepest (the closest to CWD) .bake.toml is preferred."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            tempfile.TemporaryDirectory() as fake_home,
+        ):
+            cwd = os.path.join(tmpdir, "anc1/anc2/wd/")
+            _write_toml(
+                Path(cwd).parent.parent / ".bake.toml", "[formatter]\ntab_width = 7\n"
+            )
+            _write_toml(
+                Path(cwd).parent.parent.parent / ".bake.toml",
+                "[formatter]\ntab_width = 999\n",
+            )
+            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 2\n")
+            with _fake_home(fake_home), _fake_cwd(cwd):
+                result = Config.load_or_default()[0]
+        assert result.formatter.tab_width == 7
+
     def test_home_bake_toml_used_when_no_cwd_config(self):
         """~/.bake.toml is used when there is no cwd config."""
         with (
@@ -287,8 +308,9 @@ class TestLoadOrDefault:
         """Invalid cwd .bake.toml is not skipped, the user is told it's invalid"""
         with tempfile.TemporaryDirectory() as cwd:
             (Path(cwd) / ".bake.toml").write_text("not valid toml !!!")
-            with _fake_cwd(cwd), pytest.raises(ValueError):
+            with _fake_cwd(cwd), pytest.raises(ValueError) as exc_info:
                 Config.load_or_default()
+            assert type(exc_info.value.__cause__) is tomllib.TOMLDecodeError
 
     def test_broken_home_config_is_reported(self):
         """Invalid home config is reported"""
@@ -297,8 +319,13 @@ class TestLoadOrDefault:
             tempfile.TemporaryDirectory() as fake_home,
         ):
             (Path(fake_home) / ".bake.toml").write_text("not valid toml !!!")
-            with _fake_home(fake_home), _fake_cwd(cwd), pytest.raises(ValueError):
+            with (
+                _fake_home(fake_home),
+                _fake_cwd(cwd),
+                pytest.raises(ValueError) as exc_info,
+            ):
                 Config.load_or_default()
+            assert type(exc_info.value.__cause__) is tomllib.TOMLDecodeError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,9 +126,9 @@ class TestLoad:
     def test_missing_explicit_path_raises_file_not_found(self):
         with pytest.raises(FileNotFoundError) as exc_info:
             Config.load(Path("/nonexistent/path/config.toml"))
-        assert (
-            str(exc_info.value)
-            == "Configuration file not found at /nonexistent/path/config.toml"
+        assert str(exc_info.value) in (
+            "Configuration file not found at /nonexistent/path/config.toml",
+            "Configuration file not found at \\nonexistent\\path\\config.toml",
         )
 
     def test_invalid_toml_raises_value_error(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,7 @@ class TestXdgConfigPath:
             tempfile.TemporaryDirectory() as fake_home,
             tempfile.TemporaryDirectory() as xdg,
         ):
+            _write_toml(Path(xdg) / "bake.toml", "[formatter]\n")
             os.environ["XDG_CONFIG_HOME"] = xdg
             with _fake_home(fake_home):
                 result = Config.determine_config_path()
@@ -83,6 +84,7 @@ class TestXdgConfigPath:
         """Falls back to ~/.config/bake.toml when no XDG var and no ~/.bake.toml."""
         with tempfile.TemporaryDirectory() as fake_home:
             with _fake_home(fake_home):
+                _write_toml(Path(fake_home) / ".config" / "bake.toml", "[formatter]\n")
                 result = Config.determine_config_path()
             assert result == Path(fake_home) / ".config" / "bake.toml"
 
@@ -91,16 +93,19 @@ class TestXdgConfigPath:
         with tempfile.TemporaryDirectory() as fake_home:
             os.environ["XDG_CONFIG_HOME"] = "   "
             with _fake_home(fake_home):
+                _write_toml(Path(fake_home) / ".config" / "bake.toml", "[formatter]\n")
                 result = Config.determine_config_path()
             assert result == Path(fake_home) / ".config" / "bake.toml"
 
-    def test_returned_path_may_not_exist(self):
-        """_xdg_config_path does not require the file to exist."""
-        with tempfile.TemporaryDirectory() as fake_home:
-            with _fake_home(fake_home):
-                result = Config.determine_config_path()
-            assert isinstance(result, Path)
-            assert not result.exists()
+    def test_returned_path_must_exist(self):
+        """``Config.determine_config_path()`` must return either an existent path or None"""
+        with tempfile.TemporaryDirectory() as fake_home, _fake_home(fake_home):
+            result = Config.determine_config_path()
+            assert result is None
+
+            _write_toml(Path(fake_home) / ".config" / "bake.toml", "[formatter]\n")
+            result = Config.determine_config_path()
+            assert result == Path(fake_home) / ".config" / "bake.toml"
 
 
 # ---------------------------------------------------------------------------
@@ -115,13 +120,16 @@ class TestLoad:
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "my.toml"
             _write_toml(p, "[formatter]\ntab_width = 4\n")
-            result = Config.load(p)
+            result = Config.load(p)[0]
             assert result.formatter.tab_width == 4
 
     def test_missing_explicit_path_raises_file_not_found(self):
         with pytest.raises(FileNotFoundError) as exc_info:
             Config.load(Path("/nonexistent/path/config.toml"))
-        assert "bake.toml" in str(exc_info.value)
+        assert (
+            str(exc_info.value)
+            == "Configuration file not found at /nonexistent/path/config.toml"
+        )
 
     def test_invalid_toml_raises_value_error(self):
         with tempfile.TemporaryDirectory() as d:
@@ -135,14 +143,14 @@ class TestLoad:
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "extra.toml"
             _write_toml(p, "[formatter]\ntab_width = 3\nunknown_key = true\n")
-            result = Config.load(p)
+            result = Config.load(p)[0]
             assert result.formatter.tab_width == 3
 
     def test_global_debug_and_verbose_flags(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "flags.toml"
             _write_toml(p, "debug = true\nverbose = true\n")
-            result = Config.load(p)
+            result = Config.load(p)[0]
             assert result.debug is True
             assert result.verbose is True
 
@@ -151,7 +159,7 @@ class TestLoad:
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "empty.toml"
             _write_toml(p, "# empty\n")
-            result = Config.load(p)
+            result = Config.load(p)[0]
             defaults = FormatterConfig()
             assert result.formatter.tab_width == defaults.tab_width
             assert result.formatter.max_line_length == defaults.max_line_length
@@ -182,7 +190,7 @@ align_variable_assignments = true
 align_across_comments = true
 """,
             )
-            f = Config.load(p).formatter
+            f = Config.load(p)[0].formatter
             assert f.space_around_assignment is False
             assert f.space_before_colon is True
             assert f.space_after_colon is False
@@ -223,7 +231,7 @@ class TestLoadOrDefault:
             _fake_home(fake_home),
             _fake_cwd(cwd),
         ):
-            result = Config.load_or_default()
+            result = Config.load_or_default()[0]
         assert isinstance(result, Config)
         assert isinstance(result.formatter, FormatterConfig)
         assert result.debug is False
@@ -237,7 +245,7 @@ class TestLoadOrDefault:
             _write_toml(Path(cwd) / ".bake.toml", "[formatter]\ntab_width = 7\n")
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 2\n")
             with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
+                result = Config.load_or_default()[0]
         assert result.formatter.tab_width == 7
 
     def test_home_bake_toml_used_when_no_cwd_config(self):
@@ -248,7 +256,7 @@ class TestLoadOrDefault:
         ):
             _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 6\n")
             with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
+                result = Config.load_or_default()[0]
         assert result.formatter.tab_width == 6
 
     def test_xdg_config_used_when_home_file_absent(self):
@@ -261,52 +269,36 @@ class TestLoadOrDefault:
             _write_toml(Path(xdg) / "bake.toml", "[formatter]\ntab_width = 5\n")
             os.environ["XDG_CONFIG_HOME"] = xdg
             with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
+                result = Config.load_or_default()[0]
         assert result.formatter.tab_width == 5
 
     def test_explicit_path_used_directly(self):
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "custom.toml"
             _write_toml(p, "[formatter]\ntab_width = 9\n")
-            result = Config.load_or_default(config_path=p)
+            result = Config.load_or_default(config_path=p)[0]
         assert result.formatter.tab_width == 9
 
-    def test_explicit_missing_path_raises_when_explicit_true(self):
+    def test_explicit_path_missing_raises(self):
         with pytest.raises(FileNotFoundError):
-            Config.load_or_default(
-                config_path=Path("/nonexistent/config.toml"),
-                explicit=True,
-            )
+            Config.load_or_default(config_path=Path("/nonexistent/config.toml"))
 
-    def test_explicit_missing_path_returns_defaults_when_explicit_false(self):
-        result = Config.load_or_default(
-            config_path=Path("/nonexistent/config.toml"),
-            explicit=False,
-        )
-        assert isinstance(result.formatter, FormatterConfig)
-
-    def test_broken_cwd_config_falls_through_to_home(self):
-        """Invalid cwd .bake.toml is skipped; home config is tried next."""
-        with (
-            tempfile.TemporaryDirectory() as cwd,
-            tempfile.TemporaryDirectory() as fake_home,
-        ):
+    def test_broken_cwd_config_is_reported(self):
+        """Invalid cwd .bake.toml is not skipped, the user is told it's invalid"""
+        with tempfile.TemporaryDirectory() as cwd:
             (Path(cwd) / ".bake.toml").write_text("not valid toml !!!")
-            _write_toml(Path(fake_home) / ".bake.toml", "[formatter]\ntab_width = 3\n")
-            with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
-        assert result.formatter.tab_width == 3
+            with _fake_cwd(cwd), pytest.raises(ValueError):
+                Config.load_or_default()
 
-    def test_broken_home_config_falls_through_to_defaults(self):
-        """Invalid home config returns defaults rather than raising."""
+    def test_broken_home_config_is_reported(self):
+        """Invalid home config is reported"""
         with (
             tempfile.TemporaryDirectory() as cwd,
             tempfile.TemporaryDirectory() as fake_home,
         ):
             (Path(fake_home) / ".bake.toml").write_text("not valid toml !!!")
-            with _fake_home(fake_home), _fake_cwd(cwd):
-                result = Config.load_or_default()
-        assert isinstance(result.formatter, FormatterConfig)
+            with _fake_home(fake_home), _fake_cwd(cwd), pytest.raises(ValueError):
+                Config.load_or_default()
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +313,7 @@ class TestToDict:
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "rt.toml"
             _write_toml(p, "[formatter]\ntab_width = 4\nmax_line_length = 100\n")
-            result = Config.load(p)
+            result = Config.load(p)[0]
         d = result.to_dict()
         assert d["formatter"]["tab_width"] == 4
         assert d["formatter"]["max_line_length"] == 100


### PR DESCRIPTION
Address #100.

1. Changed the config search procedure:
    1.1. *.bake.toml* files are now searched in the same manner as git looks for *.git* directories.
    1.2. Invalid config files are reported and not silently skipped.
2. Modified related tests to match the new expected behavior.